### PR TITLE
Step07 - 인프라레이어 코드 및 통합테스트 작성

### DIFF
--- a/src/main/java/kr/hhplus/be/server/application/bestseller/BestSellerScheduler.java
+++ b/src/main/java/kr/hhplus/be/server/application/bestseller/BestSellerScheduler.java
@@ -1,0 +1,57 @@
+package kr.hhplus.be.server.application.bestseller;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import kr.hhplus.be.server.domain.bestseller.BestSeller;
+import kr.hhplus.be.server.domain.bestseller.BestSellerService;
+import kr.hhplus.be.server.domain.order.Order;
+import kr.hhplus.be.server.domain.order.OrderProduct;
+import kr.hhplus.be.server.domain.order.OrderService;
+import kr.hhplus.be.server.domain.product.Product;
+import kr.hhplus.be.server.domain.product.ProductService;
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class BestSellerScheduler {
+
+	private final OrderService orderService;
+	private final ProductService productService;
+	private final BestSellerService bestSellerService;
+
+	@Scheduled(cron = "0 0 * * * *")
+	@Transactional
+	public void insertBestSeller() {
+		LocalDateTime now = LocalDateTime.now();
+
+		// 1시간 전부터 현재까지의 주문을 가져옴
+		List<Order> findOrders = orderService.getPaidOrdersWithinOneHour(now);
+
+		Map<Long, Long> productSalesMap = findOrders.stream()
+			.flatMap(order -> order.getOrderProducts().stream())
+			.collect(Collectors.groupingBy(
+				OrderProduct::getProductId,
+				Collectors.summingLong(OrderProduct::getQuantity)
+			));
+
+		productSalesMap.forEach((productId, salesQuantity) -> {
+				// Product 정보를 조회합니다.
+				Product product = productService.getProductById(productId);
+				if (product == null) {
+					throw new IllegalArgumentException("Product not found for ID: " + productId);
+				}
+				// BestSeller 객체를 생성합니다.
+				BestSeller productInBestSeller = bestSellerService.getProductInBestSeller(product);
+				productInBestSeller.addSalesCount(salesQuantity);
+				bestSellerService.save(productInBestSeller); // TODO 단건씩 업데이트 쳐야할까?
+			}
+		);
+	}
+}

--- a/src/main/java/kr/hhplus/be/server/application/order/facade/OrderFacade.java
+++ b/src/main/java/kr/hhplus/be/server/application/order/facade/OrderFacade.java
@@ -1,8 +1,11 @@
 package kr.hhplus.be.server.application.order.facade;
 
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
+import jakarta.persistence.Transient;
 import kr.hhplus.be.server.application.order.dto.OrderCreateCommand;
+import kr.hhplus.be.server.application.order.dto.OrderCreateResult;
 import kr.hhplus.be.server.domain.coupon.CouponService;
 import kr.hhplus.be.server.domain.coupon.PublishedCoupon;
 import kr.hhplus.be.server.domain.order.Order;
@@ -22,7 +25,8 @@ public class OrderFacade {
 	private final OrderService orderService;
 	private final UserService userService;
 
-	public Order createOrder(OrderCreateCommand command) {
+	@Transactional
+	public OrderCreateResult createOrder(OrderCreateCommand command) {
 
 		User findUser = userService.getUserById(command.userId());
 
@@ -33,7 +37,7 @@ public class OrderFacade {
 		command.orderLines().forEach(line -> {
 			Product product = productService.getProductById(line.productId());
 			productService.decreaseStock(product, line.quantity());
-			order.addOrderProduct(product, line.productId());
+			order.addOrderProduct(product, line.quantity());
 		});
 
 		// 적용할 쿠폰이 있어?
@@ -43,6 +47,6 @@ public class OrderFacade {
 			order.applyCoupon(findPublishedCoupon);
 		}
 
-		return orderService.order(order);
+		return OrderCreateResult.from(orderService.order(order));
 	}
 }

--- a/src/main/java/kr/hhplus/be/server/application/order/scheduler/OrderExpireScheduler.java
+++ b/src/main/java/kr/hhplus/be/server/application/order/scheduler/OrderExpireScheduler.java
@@ -31,7 +31,7 @@ public class OrderExpireScheduler {
 	@Transactional
 	public void expireOrderThenRestoreCouponAndStock() {
 		LocalDateTime deadLine = LocalDateTime.now().minusMinutes(5);
-		List<Order> expireTargetOrders = orderService.getOverDueOrderIds(deadLine);
+		List<Order> expireTargetOrders = orderService.getOverDueOrders(deadLine);
 
 		for (Order order : expireTargetOrders) {
 			try {

--- a/src/main/java/kr/hhplus/be/server/config/jpa/JpaConfig.java
+++ b/src/main/java/kr/hhplus/be/server/config/jpa/JpaConfig.java
@@ -2,18 +2,20 @@ package kr.hhplus.be.server.config.jpa;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
 import org.springframework.orm.jpa.JpaTransactionManager;
 import org.springframework.transaction.PlatformTransactionManager;
 
+@Profile("!test")
 @Configuration
 @EnableJpaAuditing
 // @EnableJpaRepositories
 public class JpaConfig {
 
-    @Bean
-    public PlatformTransactionManager transactionManager() {
-        return new JpaTransactionManager();
-    }
+	@Bean
+	public PlatformTransactionManager transactionManager() {
+		return new JpaTransactionManager();
+	}
 }

--- a/src/main/java/kr/hhplus/be/server/domain/base/BaseTimeEntity.java
+++ b/src/main/java/kr/hhplus/be/server/domain/base/BaseTimeEntity.java
@@ -6,7 +6,6 @@ import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
-import jakarta.persistence.Column;
 import jakarta.persistence.EntityListeners;
 import jakarta.persistence.MappedSuperclass;
 
@@ -18,7 +17,6 @@ public abstract class BaseTimeEntity {
 	private LocalDateTime createdAt;
 
 	@LastModifiedDate
-	@Column(name = "updated_at", nullable = false)
 	private LocalDateTime updatedAt;
 
 	public LocalDateTime getCreatedAt() {

--- a/src/main/java/kr/hhplus/be/server/domain/bestseller/BestSeller.java
+++ b/src/main/java/kr/hhplus/be/server/domain/bestseller/BestSeller.java
@@ -8,6 +8,7 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 import kr.hhplus.be.server.domain.base.BaseTimeEntity;
+import kr.hhplus.be.server.domain.product.Product;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -44,5 +45,14 @@ public class BestSeller extends BaseTimeEntity {
 		this.price = price;
 		this.stock = stock;
 		this.salesCount = salesCount;
+	}
+
+	public static BestSeller create(Product product, Long salesCount) {
+		return new BestSeller(product.getId(), product.getProductName(), product.getDescription(), product.getPrice(),
+			product.getStock(), salesCount);
+	}
+
+	public void addSalesCount(Long salesQuantity) {
+		this.salesCount += salesQuantity;
 	}
 }

--- a/src/main/java/kr/hhplus/be/server/domain/bestseller/BestSellerRepository.java
+++ b/src/main/java/kr/hhplus/be/server/domain/bestseller/BestSellerRepository.java
@@ -3,9 +3,18 @@ package kr.hhplus.be.server.domain.bestseller;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Optional;
 
 public interface BestSellerRepository {
 
-	List<BestSeller> findTopBySalesCountSince(LocalDate from, int limit);
+	BestSeller save(BestSeller bestSeller);
+
+	BestSeller findById(Long bestSellerId);
+
+	List<BestSeller> findTopBySalesCountSince(LocalDateTime from, int limit);
+
+	void saveAll(List<BestSeller> bestSellers);
+
+	Optional<BestSeller> findByProductId(Long productId);
 
 }

--- a/src/main/java/kr/hhplus/be/server/domain/bestseller/BestSellerService.java
+++ b/src/main/java/kr/hhplus/be/server/domain/bestseller/BestSellerService.java
@@ -5,7 +5,9 @@ import java.time.LocalDateTime;
 import java.util.List;
 
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
+import kr.hhplus.be.server.domain.product.Product;
 import lombok.RequiredArgsConstructor;
 
 @Service
@@ -14,8 +16,23 @@ public class BestSellerService {
 
 	private final BestSellerRepository bestSellerRepository;
 
-	public List<BestSeller> getTopBestSellers(int days, int limit) {
-		LocalDate from = LocalDate.now().minusDays(days);
+	@Transactional
+	public BestSeller save(BestSeller bestSeller) {
+		return bestSellerRepository.save(bestSeller);
+	}
+
+	public List<BestSeller> getTopBestSellers(LocalDateTime now, int days, int limit) {
+		LocalDateTime from = now.minusDays(days);
 		return bestSellerRepository.findTopBySalesCountSince(from, limit);
+	}
+
+	public BestSeller getProductInBestSeller(Product product) {
+		return bestSellerRepository.findByProductId(product.getId())
+			.orElseGet(() -> {
+				// BestSeller 생성 (판매 수량 0으로 초기화)
+				BestSeller newBestSeller = BestSeller.create(product, 0L);
+				// 생성된 BestSeller를 DB에 저장 후 반환
+				return bestSellerRepository.save(newBestSeller);
+			});
 	}
 }

--- a/src/main/java/kr/hhplus/be/server/domain/coupon/Coupon.java
+++ b/src/main/java/kr/hhplus/be/server/domain/coupon/Coupon.java
@@ -120,8 +120,7 @@ public class Coupon extends BaseTimeEntity {
 			this.discountType,
 			this.discountValue,
 			this.validFrom,
-			this.validTo,
-			this.id
+			this.validTo
 		);
 	}
 }

--- a/src/main/java/kr/hhplus/be/server/domain/coupon/CouponSnapshot.java
+++ b/src/main/java/kr/hhplus/be/server/domain/coupon/CouponSnapshot.java
@@ -3,13 +3,32 @@ package kr.hhplus.be.server.domain.coupon;
 import java.math.BigDecimal;
 import java.time.LocalDate;
 
+import jakarta.persistence.Embeddable;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import kr.hhplus.be.server.domain.coupon.discountpolicy.DiscountType;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
-public record CouponSnapshot(
-	String couponName,
-	DiscountType discountType,
-	BigDecimal discountValue,
-	LocalDate validFrom,
-	LocalDate validTo,
-	Long originalCouponId          // 추적용
-) {}
+@Embeddable
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@EqualsAndHashCode
+public class CouponSnapshot {
+
+	private String couponName;
+
+	@Enumerated(EnumType.STRING)
+	private DiscountType discountType;
+
+	private BigDecimal discountValue;
+
+	private LocalDate validFrom;
+	private LocalDate validTo;
+
+	private Long originalCouponId;
+}

--- a/src/main/java/kr/hhplus/be/server/domain/coupon/CouponSnapshot.java
+++ b/src/main/java/kr/hhplus/be/server/domain/coupon/CouponSnapshot.java
@@ -29,6 +29,4 @@ public class CouponSnapshot {
 
 	private LocalDate validFrom;
 	private LocalDate validTo;
-
-	private Long originalCouponId;
 }

--- a/src/main/java/kr/hhplus/be/server/domain/coupon/PublishedCoupon.java
+++ b/src/main/java/kr/hhplus/be/server/domain/coupon/PublishedCoupon.java
@@ -59,13 +59,13 @@ public class PublishedCoupon {
 			throw new IllegalArgumentException("가격이 null이거나 0 이하입니다.");
 		}
 
-		if (now.isBefore(couponSnapshot.validFrom()) || now.isAfter(couponSnapshot.validTo())) {
-			throw new CouponExpiredException(couponSnapshot.validTo());
+		if (now.isBefore(couponSnapshot.getValidFrom()) || now.isAfter(couponSnapshot.getValidTo())) {
+			throw new CouponExpiredException(couponSnapshot.getValidTo());
 		}
 
 		this.isUsed = true;
-		return this.couponSnapshot.discountType()
-			.toPolicy(couponSnapshot.discountValue())
+		return this.couponSnapshot.getDiscountType()
+			.toPolicy(couponSnapshot.getDiscountValue())
 			.apply(originalPrice);
 	}
 

--- a/src/main/java/kr/hhplus/be/server/domain/order/Order.java
+++ b/src/main/java/kr/hhplus/be/server/domain/order/Order.java
@@ -2,6 +2,7 @@ package kr.hhplus.be.server.domain.order;
 
 import java.math.BigDecimal;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -48,6 +49,8 @@ public class Order extends BaseTimeEntity {
 
 	private BigDecimal discountedPrice;
 
+	private LocalDateTime orderedAt;
+
 	private Order(Long userId, Long publishedCouponId, List<OrderProduct> orderProducts, OrderStatus orderStatus,
 		BigDecimal totalPrice, BigDecimal discountedPrice) {
 		this.userId = userId;
@@ -56,6 +59,7 @@ public class Order extends BaseTimeEntity {
 		this.orderStatus = orderStatus;
 		this.totalPrice = totalPrice;
 		this.discountedPrice = discountedPrice;
+		this.orderedAt = LocalDateTime.now();
 	}
 
 	public static Order create(User user) {

--- a/src/main/java/kr/hhplus/be/server/domain/order/OrderProduct.java
+++ b/src/main/java/kr/hhplus/be/server/domain/order/OrderProduct.java
@@ -17,7 +17,7 @@ import lombok.NoArgsConstructor;
 @Table(name = "order_product")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
-public class OrderProduct extends BaseTimeEntity {
+public class OrderProduct {
 
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/kr/hhplus/be/server/domain/order/OrderRepository.java
+++ b/src/main/java/kr/hhplus/be/server/domain/order/OrderRepository.java
@@ -13,4 +13,6 @@ public interface OrderRepository {
 
 	List<OrderProduct> findOrderProductsByOrderId(Long orderId);
 
+	List<Order> findPaidOrdersWithinOneHour(LocalDateTime now);
+
 }

--- a/src/main/java/kr/hhplus/be/server/domain/order/OrderService.java
+++ b/src/main/java/kr/hhplus/be/server/domain/order/OrderService.java
@@ -46,9 +46,15 @@ public class OrderService {
 		return orderRepository.findOrderProductsByOrderId(orderId);
 	}
 
-	public List<Order> getOverDueOrderIds(LocalDateTime deadLine) {
+	public List<Order> getOverDueOrders(LocalDateTime deadLine) {
 		if (deadLine == null)
 			throw new IllegalArgumentException("마감 기한은 null일 수 없습니다.");
 		return orderRepository.findAllPendingBefore(OrderStatus.PENDING, deadLine);
+	}
+
+	public List<Order> getOrdersByCreatedAtBetween(LocalDateTime start, LocalDateTime end) {
+		if (start == null || end == null)
+			throw new IllegalArgumentException("시작일과 종료일은 null일 수 없습니다.");
+		return orderRepository.findPaidOrdersWithinOneHour(start);
 	}
 }

--- a/src/main/java/kr/hhplus/be/server/domain/order/OrderService.java
+++ b/src/main/java/kr/hhplus/be/server/domain/order/OrderService.java
@@ -52,9 +52,9 @@ public class OrderService {
 		return orderRepository.findAllPendingBefore(OrderStatus.PENDING, deadLine);
 	}
 
-	public List<Order> getOrdersByCreatedAtBetween(LocalDateTime start, LocalDateTime end) {
-		if (start == null || end == null)
+	public List<Order> getPaidOrdersWithinOneHour(LocalDateTime now) {
+		if (now == null)
 			throw new IllegalArgumentException("시작일과 종료일은 null일 수 없습니다.");
-		return orderRepository.findPaidOrdersWithinOneHour(start);
+		return orderRepository.findPaidOrdersWithinOneHour(now);
 	}
 }

--- a/src/main/java/kr/hhplus/be/server/infra/bestseller/BestSellerJpaRepository.java
+++ b/src/main/java/kr/hhplus/be/server/infra/bestseller/BestSellerJpaRepository.java
@@ -1,0 +1,24 @@
+package kr.hhplus.be.server.infra.bestseller;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+import kr.hhplus.be.server.domain.bestseller.BestSeller;
+
+public interface BestSellerJpaRepository extends JpaRepository<BestSeller, Long> {
+
+	@Query(
+		"SELECT b FROM BestSeller b " +
+			"WHERE b.createdAt >= :from " +
+			"ORDER BY b.salesCount DESC " +
+			"LIMIT :limit"
+	)
+	List<BestSeller> findTopBySalesCountSince(LocalDateTime from, int limit);
+
+	Optional<BestSeller> findByProductId(Long productId);
+}

--- a/src/main/java/kr/hhplus/be/server/infra/bestseller/BestSellerRepositoryImpl.java
+++ b/src/main/java/kr/hhplus/be/server/infra/bestseller/BestSellerRepositoryImpl.java
@@ -1,0 +1,46 @@
+package kr.hhplus.be.server.infra.bestseller;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+import org.springframework.stereotype.Repository;
+
+import kr.hhplus.be.server.domain.bestseller.BestSeller;
+import kr.hhplus.be.server.domain.bestseller.BestSellerRepository;
+import lombok.RequiredArgsConstructor;
+
+@Repository
+@RequiredArgsConstructor
+public class BestSellerRepositoryImpl implements BestSellerRepository {
+
+	private final BestSellerJpaRepository bestSellerJpaRepository;
+
+	@Override
+	public BestSeller save(BestSeller bestSeller) {
+		return bestSellerJpaRepository.save(bestSeller);
+	}
+
+	@Override
+	public void saveAll(List<BestSeller> bestSellers) {
+		bestSellerJpaRepository.saveAll(bestSellers);
+	}
+
+	@Override
+	public BestSeller findById(Long bestSellerId) {
+		return bestSellerJpaRepository.findById(bestSellerId).orElseThrow(
+			() -> new IllegalArgumentException("인기상품이 존재하지 않습니다.")
+		);
+	}
+
+	@Override
+	public List<BestSeller> findTopBySalesCountSince(LocalDateTime from, int limit) {
+		return bestSellerJpaRepository.findTopBySalesCountSince(from, limit);
+	}
+
+	@Override
+	public Optional<BestSeller> findByProductId(Long productId) {
+		return bestSellerJpaRepository.findByProductId(productId);
+	}
+}

--- a/src/main/java/kr/hhplus/be/server/infra/coupon/CouponJpaRepository.java
+++ b/src/main/java/kr/hhplus/be/server/infra/coupon/CouponJpaRepository.java
@@ -1,0 +1,8 @@
+package kr.hhplus.be.server.infra.coupon;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import kr.hhplus.be.server.domain.coupon.Coupon;
+
+public interface CouponJpaRepository extends JpaRepository<Coupon, Long> {
+}

--- a/src/main/java/kr/hhplus/be/server/infra/coupon/CouponRepositoryImpl.java
+++ b/src/main/java/kr/hhplus/be/server/infra/coupon/CouponRepositoryImpl.java
@@ -1,0 +1,53 @@
+package kr.hhplus.be.server.infra.coupon;
+
+import org.springframework.stereotype.Repository;
+
+import jakarta.persistence.EntityNotFoundException;
+import kr.hhplus.be.server.domain.coupon.Coupon;
+import kr.hhplus.be.server.domain.coupon.CouponRepository;
+import kr.hhplus.be.server.domain.coupon.PublishedCoupon;
+import lombok.RequiredArgsConstructor;
+
+@Repository
+@RequiredArgsConstructor
+public class CouponRepositoryImpl implements CouponRepository {
+
+	private final CouponJpaRepository couponJpaRepository;
+	private final PublishedCouponJpaRepository publishedCouponJpaRepository;
+
+	@Override
+	public Coupon save(Coupon coupon) {
+		return couponJpaRepository.save(coupon);
+	}
+
+	@Override
+	public Coupon findById(Long couponId) {
+		return couponJpaRepository.findById(couponId).orElseThrow(
+			() -> new EntityNotFoundException("쿠폰을 찾을 수 없습니다.")
+		);
+	}
+
+	@Override
+	public PublishedCoupon savePublishedCoupon(PublishedCoupon publishedCoupon) {
+		return publishedCouponJpaRepository.save(publishedCoupon);
+	}
+
+	@Override
+	public PublishedCoupon findPublishedCouponById(Long publishedCouponId) {
+		return publishedCouponJpaRepository.findById(publishedCouponId).orElseThrow(
+			() -> new EntityNotFoundException("발행된 쿠폰을 찾을 수 없습니다.")
+		);
+	}
+
+	@Override
+	public PublishedCoupon findPublishedCouponBy(Long userId, Long couponId) {
+		return publishedCouponJpaRepository.findByUserIdAndCouponId(userId, couponId).orElseThrow(
+			() -> new EntityNotFoundException("발행된 쿠폰을 찾을 수 없습니다.")
+		);
+	}
+
+	@Override
+	public boolean existsPublishedCouponBy(Long userId, Long couponId) {
+		return publishedCouponJpaRepository.existsByUserIdAndCouponId(userId, couponId);
+	}
+}

--- a/src/main/java/kr/hhplus/be/server/infra/coupon/PublishedCouponJpaRepository.java
+++ b/src/main/java/kr/hhplus/be/server/infra/coupon/PublishedCouponJpaRepository.java
@@ -1,0 +1,14 @@
+package kr.hhplus.be.server.infra.coupon;
+
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import kr.hhplus.be.server.domain.coupon.PublishedCoupon;
+
+public interface PublishedCouponJpaRepository extends JpaRepository<PublishedCoupon, Long> {
+
+	Optional<PublishedCoupon> findByUserIdAndCouponId(Long userId, Long couponId);
+
+	boolean existsByUserIdAndCouponId(Long userId, Long couponId);
+}

--- a/src/main/java/kr/hhplus/be/server/infra/order/OrderJpaRepository.java
+++ b/src/main/java/kr/hhplus/be/server/infra/order/OrderJpaRepository.java
@@ -13,12 +13,12 @@ import kr.hhplus.be.server.domain.order.OrderStatus;
 public interface OrderJpaRepository extends JpaRepository<Order, Long> {
 
 	@Query(
-		"SELECT o FROM Order o WHERE o.orderStatus = :orderStatus AND o.createdAt < :deadline"
+		"SELECT o FROM Order o WHERE o.orderStatus = :orderStatus AND o.orderedAt < :deadline"
 	)
 	List<Order> findAllPendingBefore(@Param("orderStatus") OrderStatus orderStatus,
 		@Param("deadline") LocalDateTime deadline);
 
-	@Query("SELECT o FROM Order o WHERE o.orderStatus = 'PAID' AND o.createdAt >= :oneHourAgo AND o.createdAt < :now")
+	@Query("SELECT o FROM Order o WHERE o.orderStatus = 'PAID' AND o.orderedAt >= :oneHourAgo AND o.orderedAt < :now")
 	List<Order> findPaidOrdersWithinOneHour(@Param("oneHourAgo") LocalDateTime oneHourAgo,
 		@Param("now") LocalDateTime now);
 }

--- a/src/main/java/kr/hhplus/be/server/infra/order/OrderJpaRepository.java
+++ b/src/main/java/kr/hhplus/be/server/infra/order/OrderJpaRepository.java
@@ -1,0 +1,24 @@
+package kr.hhplus.be.server.infra.order;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import kr.hhplus.be.server.domain.order.Order;
+import kr.hhplus.be.server.domain.order.OrderStatus;
+
+public interface OrderJpaRepository extends JpaRepository<Order, Long> {
+
+	@Query(
+		"SELECT o FROM Order o WHERE o.orderStatus = :orderStatus AND o.createdAt < :deadline"
+	)
+	List<Order> findAllPendingBefore(@Param("orderStatus") OrderStatus orderStatus,
+		@Param("deadline") LocalDateTime deadline);
+
+	@Query("SELECT o FROM Order o WHERE o.orderStatus = 'PAID' AND o.createdAt >= :oneHourAgo AND o.createdAt < :now")
+	List<Order> findPaidOrdersWithinOneHour(@Param("oneHourAgo") LocalDateTime oneHourAgo,
+		@Param("now") LocalDateTime now);
+}

--- a/src/main/java/kr/hhplus/be/server/infra/order/OrderProductJpaRepository.java
+++ b/src/main/java/kr/hhplus/be/server/infra/order/OrderProductJpaRepository.java
@@ -1,0 +1,12 @@
+package kr.hhplus.be.server.infra.order;
+
+import java.util.List;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import kr.hhplus.be.server.domain.order.OrderProduct;
+
+public interface OrderProductJpaRepository extends JpaRepository<OrderProduct, Long> {
+
+	List<OrderProduct> findAllByOrderId(Long orderId);
+}

--- a/src/main/java/kr/hhplus/be/server/infra/order/OrderRepositoryImpl.java
+++ b/src/main/java/kr/hhplus/be/server/infra/order/OrderRepositoryImpl.java
@@ -1,0 +1,59 @@
+package kr.hhplus.be.server.infra.order;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import org.springframework.stereotype.Repository;
+
+import kr.hhplus.be.server.domain.order.Order;
+import kr.hhplus.be.server.domain.order.OrderProduct;
+import kr.hhplus.be.server.domain.order.OrderRepository;
+import kr.hhplus.be.server.domain.order.OrderStatus;
+import lombok.RequiredArgsConstructor;
+
+@Repository
+@RequiredArgsConstructor
+public class OrderRepositoryImpl implements OrderRepository {
+
+	private final OrderJpaRepository orderJpaRepository;
+	private final OrderProductJpaRepository orderProductJpaRepository;
+
+	@Override
+	public Order findOrderById(Long orderId) {
+		Order findOrder = orderJpaRepository.findById(orderId)
+			.orElseThrow(() -> new IllegalArgumentException("주문을 찾을 수 없습니다."));
+		List<OrderProduct> orderProducts = orderProductJpaRepository.findAllByOrderId(orderId);
+		findOrder.assignOrderProduct(orderProducts);
+		return findOrder;
+	}
+
+	@Override
+	public Order save(Order order) {
+		Order savedOrder = orderJpaRepository.save(order);
+
+		order.getOrderProducts().forEach(op -> op.assignOrderId(savedOrder.getId()));
+
+		orderProductJpaRepository.saveAll(order.getOrderProducts());
+		return savedOrder;
+	}
+
+	@Override
+	public List<Order> findAllPendingBefore(OrderStatus orderStatus, LocalDateTime deadline) {
+		return orderJpaRepository.findAllPendingBefore(orderStatus, deadline);
+	}
+
+	@Override
+	public List<OrderProduct> findOrderProductsByOrderId(Long orderId) {
+		return orderProductJpaRepository.findAllByOrderId(orderId);
+	}
+
+	@Override
+	public List<Order> findPaidOrdersWithinOneHour(LocalDateTime now) {
+		return orderJpaRepository.findPaidOrdersWithinOneHour(now.minusHours(1), now)
+			.stream()
+			.peek(order -> {
+				List<OrderProduct> orderProducts = orderProductJpaRepository.findAllByOrderId(order.getId());
+				order.assignOrderProduct(orderProducts);
+			}).toList();
+	}
+}

--- a/src/main/java/kr/hhplus/be/server/infra/point/PointHistoryJpaRepository.java
+++ b/src/main/java/kr/hhplus/be/server/infra/point/PointHistoryJpaRepository.java
@@ -1,0 +1,12 @@
+package kr.hhplus.be.server.infra.point;
+
+import java.util.List;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import kr.hhplus.be.server.domain.point.PointHistory;
+
+public interface PointHistoryJpaRepository extends JpaRepository<PointHistory, Long> {
+
+	List<PointHistory> findByPointId(Long pointId);
+}

--- a/src/main/java/kr/hhplus/be/server/infra/point/PointJpaRepository.java
+++ b/src/main/java/kr/hhplus/be/server/infra/point/PointJpaRepository.java
@@ -1,0 +1,13 @@
+package kr.hhplus.be.server.infra.point;
+
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import kr.hhplus.be.server.domain.point.Point;
+
+public interface PointJpaRepository extends JpaRepository<Point, Long> {
+
+	Optional<Point> findByUserId(Long userId);
+
+}

--- a/src/main/java/kr/hhplus/be/server/infra/point/PointRepositoryImpl.java
+++ b/src/main/java/kr/hhplus/be/server/infra/point/PointRepositoryImpl.java
@@ -1,0 +1,46 @@
+package kr.hhplus.be.server.infra.point;
+
+import java.util.List;
+
+import org.springframework.stereotype.Repository;
+
+import kr.hhplus.be.server.domain.point.Point;
+import kr.hhplus.be.server.domain.point.PointHistory;
+import kr.hhplus.be.server.domain.point.PointRepository;
+import lombok.RequiredArgsConstructor;
+
+@Repository
+@RequiredArgsConstructor
+public class PointRepositoryImpl implements PointRepository {
+
+	private final PointJpaRepository pointJpaRepository;
+	private final PointHistoryJpaRepository pointHistoryJpaRepository;
+
+	@Override
+	public Point findByUserId(Long userId) {
+		return pointJpaRepository.findByUserId(userId)
+			.orElseGet(
+				() -> {
+					Point point = Point.createZeroUserPoint(userId);
+					return pointJpaRepository.save(point);
+				}
+			);
+	}
+
+	@Override
+	public Point save(Point point) {
+		return pointJpaRepository.save(point);
+	}
+
+	@Override
+	public Point saveWithHistory(Point point, PointHistory pointHistory) {
+		Point savedPoint = pointJpaRepository.save(point);
+		pointHistoryJpaRepository.save(pointHistory);
+		return savedPoint;
+	}
+
+	@Override
+	public List<PointHistory> getPointHistoryByPointId(Long pointId) {
+		return pointHistoryJpaRepository.findByPointId(pointId);
+	}
+}

--- a/src/main/java/kr/hhplus/be/server/infra/product/ProductJpaRepository.java
+++ b/src/main/java/kr/hhplus/be/server/infra/product/ProductJpaRepository.java
@@ -1,8 +1,12 @@
 package kr.hhplus.be.server.infra.product;
 
+import java.util.List;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import kr.hhplus.be.server.domain.product.Product;
 
 public interface ProductJpaRepository extends JpaRepository<Product, Long> {
+
+	List<Product> findAllByIdIn(List<Long> porudctIds);
 }

--- a/src/main/java/kr/hhplus/be/server/infra/product/ProductRepositoryImpl.java
+++ b/src/main/java/kr/hhplus/be/server/infra/product/ProductRepositoryImpl.java
@@ -29,4 +29,9 @@ public class ProductRepositoryImpl implements ProductRepository {
 	public Product save(Product product) {
 		return productJpaRepository.save(product);
 	}
+
+	@Override
+	public List<Product> findAllByIds(List<Long> productIds) {
+		return productJpaRepository.findAllByIdIn(productIds);
+	}
 }

--- a/src/main/java/kr/hhplus/be/server/infra/user/UserJpaRepository.java
+++ b/src/main/java/kr/hhplus/be/server/infra/user/UserJpaRepository.java
@@ -1,0 +1,8 @@
+package kr.hhplus.be.server.infra.user;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import kr.hhplus.be.server.domain.user.User;
+
+public interface UserJpaRepository extends JpaRepository<User, Long> {
+}

--- a/src/main/java/kr/hhplus/be/server/infra/user/UserRepositoryImpl.java
+++ b/src/main/java/kr/hhplus/be/server/infra/user/UserRepositoryImpl.java
@@ -1,0 +1,25 @@
+package kr.hhplus.be.server.infra.user;
+
+import org.springframework.stereotype.Repository;
+
+import jakarta.persistence.EntityNotFoundException;
+import kr.hhplus.be.server.domain.user.User;
+import kr.hhplus.be.server.domain.user.UserRepository;
+import lombok.RequiredArgsConstructor;
+
+@Repository
+@RequiredArgsConstructor
+public class UserRepositoryImpl implements UserRepository {
+
+	private final UserJpaRepository userJpaRepository;
+
+	@Override
+	public User save(User user) {
+		return userJpaRepository.save(user);
+	}
+
+	@Override
+	public User findById(Long userId) {
+		return userJpaRepository.findById(userId).orElseThrow(() -> new EntityNotFoundException("User not found"));
+	}
+}

--- a/src/test/java/kr/hhplus/be/server/domain/bestseller/BestSellerServiceTest.java
+++ b/src/test/java/kr/hhplus/be/server/domain/bestseller/BestSellerServiceTest.java
@@ -30,6 +30,7 @@ class BestSellerServiceTest {
 	@DisplayName("입력한 기간(days)와 제한(limit)으로 베스트셀러를 조회한다.")
 	void getTopBestSellersWithDaysAndLimit() {
 		// given
+		LocalDateTime fixedNow = LocalDateTime.of(2023, 10, 1, 0, 0);
 		int days = 3;
 		int limit = 5;
 
@@ -42,11 +43,11 @@ class BestSellerServiceTest {
 				.salesCount(50L)
 				.build()
 		);
-		when(bestSellerRepository.findTopBySalesCountSince(any(LocalDate.class), eq(limit)))
+		when(bestSellerRepository.findTopBySalesCountSince(any(LocalDateTime.class), eq(limit)))
 			.thenReturn(mockResult);
 
 		// when
-		List<BestSeller> result = bestSellerService.getTopBestSellers(days, limit);
+		List<BestSeller> result = bestSellerService.getTopBestSellers(fixedNow, days, limit);
 
 		// then
 		assertAll(
@@ -54,7 +55,7 @@ class BestSellerServiceTest {
 			() -> assertThat(result.get(0).getProductName()).isEqualTo("상품 A")
 		);
 
-		verify(bestSellerRepository).findTopBySalesCountSince(any(LocalDate.class), eq(limit));
+		verify(bestSellerRepository).findTopBySalesCountSince(any(LocalDateTime.class), eq(limit));
 
 	}
 }

--- a/src/test/java/kr/hhplus/be/server/domain/coupon/CouponTest.java
+++ b/src/test/java/kr/hhplus/be/server/domain/coupon/CouponTest.java
@@ -167,12 +167,12 @@ class CouponTest {
 
 		// then
 		assertAll(
-			() -> assertThat(snapshot.couponName()).isEqualTo(name),
-			() -> assertThat(snapshot.discountType()).isEqualTo(discountType),
-			() -> assertThat(snapshot.discountValue()).isEqualByComparingTo(discountValue),
-			() -> assertThat(snapshot.validFrom()).isEqualTo(validFrom),
-			() -> assertThat(snapshot.validTo()).isEqualTo(validTo),
-			() -> assertThat(snapshot.originalCouponId()).isEqualTo(id)
+			() -> assertThat(snapshot.getCouponName()).isEqualTo(name),
+			() -> assertThat(snapshot.getDiscountType()).isEqualTo(discountType),
+			() -> assertThat(snapshot.getDiscountValue()).isEqualByComparingTo(discountValue),
+			() -> assertThat(snapshot.getValidFrom()).isEqualTo(validFrom),
+			() -> assertThat(snapshot.getValidTo()).isEqualTo(validTo),
+			() -> assertThat(snapshot.getOriginalCouponId()).isEqualTo(id)
 		);
 	}
 
@@ -205,12 +205,12 @@ class CouponTest {
 
 		// then
 		assertAll(
-			() -> assertThat(snapshot.couponName()).isEqualTo("오리지널"),
-			() -> assertThat(snapshot.discountValue()).isEqualByComparingTo("1000"),
-			() -> assertThat(snapshot.discountType()).isEqualTo(DiscountType.FIXED),
-			() -> assertThat(snapshot.validFrom()).isEqualTo(LocalDate.of(2025, 1, 1)),
-			() -> assertThat(snapshot.validTo()).isEqualTo(LocalDate.of(2025, 1, 31)),
-			() -> assertThat(snapshot.originalCouponId()).isEqualTo(1L)
+			() -> assertThat(snapshot.getCouponName()).isEqualTo("오리지널"),
+			() -> assertThat(snapshot.getDiscountValue()).isEqualByComparingTo("1000"),
+			() -> assertThat(snapshot.getDiscountType()).isEqualTo(DiscountType.FIXED),
+			() -> assertThat(snapshot.getValidFrom()).isEqualTo(LocalDate.of(2025, 1, 1)),
+			() -> assertThat(snapshot.getValidTo()).isEqualTo(LocalDate.of(2025, 1, 31)),
+			() -> assertThat(snapshot.getOriginalCouponId()).isEqualTo(1L)
 		);
 	}
 }

--- a/src/test/java/kr/hhplus/be/server/domain/coupon/CouponTest.java
+++ b/src/test/java/kr/hhplus/be/server/domain/coupon/CouponTest.java
@@ -171,8 +171,7 @@ class CouponTest {
 			() -> assertThat(snapshot.getDiscountType()).isEqualTo(discountType),
 			() -> assertThat(snapshot.getDiscountValue()).isEqualByComparingTo(discountValue),
 			() -> assertThat(snapshot.getValidFrom()).isEqualTo(validFrom),
-			() -> assertThat(snapshot.getValidTo()).isEqualTo(validTo),
-			() -> assertThat(snapshot.getOriginalCouponId()).isEqualTo(id)
+			() -> assertThat(snapshot.getValidTo()).isEqualTo(validTo)
 		);
 	}
 
@@ -209,8 +208,7 @@ class CouponTest {
 			() -> assertThat(snapshot.getDiscountValue()).isEqualByComparingTo("1000"),
 			() -> assertThat(snapshot.getDiscountType()).isEqualTo(DiscountType.FIXED),
 			() -> assertThat(snapshot.getValidFrom()).isEqualTo(LocalDate.of(2025, 1, 1)),
-			() -> assertThat(snapshot.getValidTo()).isEqualTo(LocalDate.of(2025, 1, 31)),
-			() -> assertThat(snapshot.getOriginalCouponId()).isEqualTo(1L)
+			() -> assertThat(snapshot.getValidTo()).isEqualTo(LocalDate.of(2025, 1, 31))
 		);
 	}
 }

--- a/src/test/java/kr/hhplus/be/server/domain/coupon/PublishedCouponTest.java
+++ b/src/test/java/kr/hhplus/be/server/domain/coupon/PublishedCouponTest.java
@@ -150,7 +150,7 @@ class PublishedCouponTest {
 			.isInstanceOf(CouponExpiredException.class)
 			.hasMessage("비즈니스 정책을 위반한 요청입니다.")
 			.extracting("detail")
-			.isEqualTo("쿠폰이 만료되었습니다. 유효 기간은 %s까지 입니다.".formatted(coupon.toSnapShot().validTo()));
+			.isEqualTo("쿠폰이 만료되었습니다. 유효 기간은 %s까지 입니다.".formatted(coupon.toSnapShot().getValidTo()));
 	}
 
 	@Test

--- a/src/test/java/kr/hhplus/be/server/domain/order/OrderServiceTest.java
+++ b/src/test/java/kr/hhplus/be/server/domain/order/OrderServiceTest.java
@@ -18,7 +18,6 @@ import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.test.util.ReflectionTestUtils;
 
 import kr.hhplus.be.server.domain.base.BaseTimeEntity;
 import kr.hhplus.be.server.domain.order.exception.OrderCannotBeExpiredException;
@@ -262,7 +261,7 @@ class OrderServiceTest {
 			.thenReturn(List.of(overdueOrder));
 
 		// when
-		List<Order> result = orderService.getOverDueOrderIds(deadline);
+		List<Order> result = orderService.getOverDueOrders(deadline);
 
 		// then
 		assertAll(
@@ -276,7 +275,7 @@ class OrderServiceTest {
 	@DisplayName("마감 기한이 null이면 IllegalArgumentException이 발생한다.")
 	void fetchOverdueOrdersFailsWhenDeadlineIsNull() {
 		// when & then
-		assertThatThrownBy(() -> orderService.getOverDueOrderIds(null))
+		assertThatThrownBy(() -> orderService.getOverDueOrders(null))
 			.isInstanceOf(IllegalArgumentException.class)
 			.hasMessage("마감 기한은 null일 수 없습니다.");
 

--- a/src/test/java/kr/hhplus/be/server/integration/BestSellerServiceIntegrationTest.java
+++ b/src/test/java/kr/hhplus/be/server/integration/BestSellerServiceIntegrationTest.java
@@ -1,0 +1,158 @@
+package kr.hhplus.be.server.integration;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.instancio.Instancio.*;
+import static org.instancio.Select.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.time.LocalDateTime;
+import java.util.Comparator;
+import java.util.List;
+import java.util.stream.IntStream;
+
+import org.instancio.Instancio;
+import org.instancio.Select;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import kr.hhplus.be.server.domain.base.BaseTimeEntity;
+import kr.hhplus.be.server.domain.bestseller.BestSeller;
+import kr.hhplus.be.server.domain.bestseller.BestSellerRepository;
+import kr.hhplus.be.server.domain.bestseller.BestSellerService;
+import kr.hhplus.be.server.domain.product.Product;
+import kr.hhplus.be.server.domain.product.ProductRepository;
+import kr.hhplus.be.server.support.IntgerationTestSupport;
+
+public class BestSellerServiceIntegrationTest extends IntgerationTestSupport {
+
+	@Autowired
+	private BestSellerService bestSellerService;
+
+	@Autowired
+	private BestSellerRepository bestSellerRepository;
+
+	@Autowired
+	private ProductRepository productRepository;
+
+	@Test
+	@DisplayName("BestSeller 저장 시, ID가 자동 할당되고 동일한 데이터가 DB에 저장된다.")
+	void testSaveBestSeller() {
+		// given: Instancio로 BestSeller 생성 (ID는 무시)
+		BestSeller bestSeller = of(BestSeller.class)
+			.ignore(field(BestSeller.class, "id"))
+			.create();
+
+		// when: BestSeller 저장 (save 메서드가 호출됨)
+		BestSeller savedBestSeller = bestSellerService.save(bestSeller);
+
+		// then: DB에서 다시 조회하여 저장된 데이터와 비교
+		BestSeller retrieved = bestSellerRepository.findById(savedBestSeller.getId());
+
+		assertAll(
+			() -> assertThat(retrieved).isNotNull(),
+			() -> assertThat(retrieved.getId()).isNotNull(),
+			() -> assertThat(retrieved.getProductId()).isEqualTo(savedBestSeller.getProductId()),
+			() -> assertThat(retrieved.getProductName()).isEqualTo(savedBestSeller.getProductName()),
+			() -> assertThat(retrieved.getDescription()).isEqualTo(savedBestSeller.getDescription()),
+			() -> assertThat(retrieved.getPrice()).isEqualByComparingTo(savedBestSeller.getPrice()),
+			() -> assertThat(retrieved.getStock()).isEqualTo(savedBestSeller.getStock()),
+			() -> assertThat(retrieved.getSalesCount()).isEqualTo(savedBestSeller.getSalesCount())
+		);
+	}
+
+	@Test
+	@DisplayName("BestSeller의 판매량 변경시 변경된 판매량이 조회된다.")
+	void changeSalesCountTest() {
+		// given: Instancio로 BestSeller 생성 (ID는 무시)
+		BestSeller bestSeller = of(BestSeller.class)
+			.ignore(field(BestSeller.class, "id"))
+			.set(field(BestSeller.class, "salesCount"), 0L)
+			.create();
+
+		BestSeller savedBestSeller = bestSellerService.save(bestSeller);
+
+		//when
+		savedBestSeller.addSalesCount(3L);
+		bestSellerService.save(bestSeller);
+
+		// then: DB에서 다시 조회하여 저장된 데이터와 비교
+		BestSeller retrieved = bestSellerRepository.findById(savedBestSeller.getId());
+
+		assertThat(retrieved.getSalesCount()).isEqualTo(3L);
+	}
+
+	@Test
+	@DisplayName("지정된 일 수 이내의 베스트셀러를 판매수 기준으로 상위 N개 가져온다")
+	void shouldReturnTopBestSellersWithinDays() {
+		// given
+		LocalDateTime fixedNow = LocalDateTime.of(2025, 4, 16, 0, 0, 0); // 또는 Clock 고정도 가능
+		LocalDateTime threeDaysAgo = fixedNow.minusDays(3);
+
+		List<BestSeller> expectedTop = IntStream.range(0, 5)
+			.mapToObj(i -> Instancio.of(BestSeller.class)
+				.ignore(field(BestSeller.class, "id"))
+				.set(field(BaseTimeEntity.class, "createdAt"), threeDaysAgo.plusDays(i))
+				.set(field(BestSeller.class, "salesCount"), 100L - (i * 10L)) // 100, 90, 80...
+				.create())
+			.toList();
+
+		bestSellerRepository.saveAll(expectedTop);
+
+		// when
+		List<BestSeller> result = bestSellerService.getTopBestSellers(fixedNow, 3, 3); // 최근 3일간 상위 3개
+
+		// then
+		assertAll(
+			() -> assertThat(result).hasSize(3),
+			() -> assertThat(result)
+				.isSortedAccordingTo(Comparator.comparingLong(BestSeller::getSalesCount).reversed()),
+			() -> assertThat(result.get(0).getSalesCount()).isEqualTo(100L),
+			() -> assertThat(result.get(1).getSalesCount()).isEqualTo(90L),
+			() -> assertThat(result.get(2).getSalesCount()).isEqualTo(80L)
+		);
+	}
+
+	@DisplayName("제품이 베스트셀러에 존재하면 해당 객체를 반환한다.")
+	@Test
+	void shouldReturnExistingOrCreateNewBestSeller() {
+		// given
+		Product product = Instancio.of(Product.class)
+			.ignore(field(Product.class, "id"))
+			.create();
+		productRepository.save(product);
+
+		// 이미 존재하는 경우
+		BestSeller existing = BestSeller.create(product, 50L);
+		bestSellerRepository.save(existing);
+
+		// when
+		BestSeller result = bestSellerService.getProductInBestSeller(product);
+
+		// then
+		assertAll(
+			() -> assertThat(result.getId()).isEqualTo(existing.getId()),
+			() -> assertThat(result.getProductId()).isEqualTo(product.getId()),
+			() -> assertThat(result.getSalesCount()).isEqualTo(50L)
+		);
+	}
+
+	@DisplayName("베스트셀러가 존재하지 않으면 새로 생성하여 반환한다")
+	@Test
+	void shouldCreateBestSellerIfNotExists() {
+		// given
+		Product product = Instancio.of(Product.class)
+			.ignore(field(Product.class, "id"))
+			.create();
+		productRepository.save(product);
+
+		// when
+		BestSeller result = bestSellerService.getProductInBestSeller(product);
+
+		// then
+		assertAll(
+			() -> assertThat(result.getProductId()).isEqualTo(product.getId()),
+			() -> assertThat(result.getSalesCount()).isEqualTo(0L)
+		);
+	}
+}

--- a/src/test/java/kr/hhplus/be/server/integration/CouponServiceIntegrationTest.java
+++ b/src/test/java/kr/hhplus/be/server/integration/CouponServiceIntegrationTest.java
@@ -1,0 +1,196 @@
+package kr.hhplus.be.server.integration;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+
+import org.instancio.Instancio;
+import org.instancio.Select;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.orm.jpa.JpaObjectRetrievalFailureException;
+
+import kr.hhplus.be.server.domain.coupon.Coupon;
+import kr.hhplus.be.server.domain.coupon.CouponRepository;
+import kr.hhplus.be.server.domain.coupon.CouponService;
+import kr.hhplus.be.server.domain.coupon.PublishedCoupon;
+import kr.hhplus.be.server.domain.coupon.discountpolicy.DiscountType;
+import kr.hhplus.be.server.domain.coupon.dto.CouponIssueCommand;
+import kr.hhplus.be.server.domain.coupon.exception.CouponAlreadyIssuedException;
+import kr.hhplus.be.server.domain.coupon.exception.CouponOutOfStockException;
+import kr.hhplus.be.server.domain.coupon.issuePolicy.CouponIssuePolicyType;
+import kr.hhplus.be.server.support.IntgerationTestSupport;
+
+public class CouponServiceIntegrationTest extends IntgerationTestSupport {
+
+	@Autowired
+	private CouponService couponService;
+
+	@Autowired
+	private CouponRepository couponRepository;
+
+	@Test
+	@DisplayName("발급된 쿠폰 ID로 조회하면 해당 쿠폰이 반환된다.")
+	void shouldReturnPublishedCouponWhenIdIsValid() {
+		// given
+		Coupon coupon = Instancio.of(Coupon.class)
+			.ignore(Select.field(Coupon.class, "id"))
+			.set(Select.field(Coupon.class, "discountValue"), BigDecimal.valueOf(1000))
+			.set(Select.field(Coupon.class, "discountType"), DiscountType.FIXED)
+			.set(Select.field(Coupon.class, "issuePolicyType"), CouponIssuePolicyType.UNLIMITED)
+			.set(Select.field(Coupon.class, "validFrom"), LocalDate.now().minusDays(1))
+			.set(Select.field(Coupon.class, "validTo"), LocalDate.now().plusDays(7))
+			.create();
+		couponRepository.save(coupon);
+
+		PublishedCoupon publishedCoupon = PublishedCoupon.create(
+			100L, // userId
+			coupon,
+			LocalDate.now()
+		);
+		couponRepository.savePublishedCoupon(publishedCoupon);
+
+		Long savedId = publishedCoupon.getId();
+
+		// when
+		PublishedCoupon result = couponService.getPublishedCouponById(savedId);
+
+		// then
+		assertAll(
+			() -> assertThat(result.getId()).isEqualTo(savedId),
+			() -> assertThat(result.getUserId()).isEqualTo(100L),
+			() -> assertThat(result.getCouponSnapshot().discountValue()).isEqualByComparingTo(BigDecimal.valueOf(1000)),
+			() -> assertThat(result.getCouponSnapshot().discountType()).isEqualTo(DiscountType.FIXED)
+		);
+	}
+
+	@Test
+	@DisplayName("발급된 쿠폰 ID가 null이면 예외가 발생한다.")
+	void shouldThrowExceptionWhenPublishedCouponIdIsNull() {
+		assertThatThrownBy(() -> couponService.getPublishedCouponById(null))
+			.isInstanceOf(IllegalArgumentException.class)
+			.hasMessage("사용하려는 쿠폰 ID는 null일 수 없습니다.");
+	}
+
+	@Test
+	@DisplayName("쿠폰을 발급하면 PublishedCoupon이 저장되고 잔여 수량이 감소한다.")
+	void shouldIssueCouponAndDecreaseRemainingCount() {
+		// given
+		Coupon coupon = Instancio.of(Coupon.class)
+			.ignore(Select.field(Coupon.class, "id"))
+			.set(Select.field(Coupon.class, "couponName"), "테스트 쿠폰")
+			.set(Select.field(Coupon.class, "discountValue"), BigDecimal.valueOf(3000))
+			.set(Select.field(Coupon.class, "discountType"), DiscountType.FIXED)
+			.set(Select.field(Coupon.class, "issuePolicyType"), CouponIssuePolicyType.LIMITED)
+			.set(Select.field(Coupon.class, "remainingCount"), 5L)
+			.set(Select.field(Coupon.class, "validFrom"), LocalDate.now().minusDays(1))
+			.set(Select.field(Coupon.class, "validTo"), LocalDate.now().plusDays(5))
+			.create();
+
+		couponRepository.save(coupon);
+
+		Long userId = 1L;
+		CouponIssueCommand command = new CouponIssueCommand(userId, coupon.getId());
+
+		// when
+		couponService.issueCoupon(command);
+
+		// then
+		PublishedCoupon issued = couponRepository.findPublishedCouponBy(userId, coupon.getId());
+		Coupon updatedCoupon = couponRepository.findById(coupon.getId());
+
+		assertAll(
+			() -> assertThat(issued.getUserId()).isEqualTo(userId),
+			() -> assertThat(updatedCoupon.getRemainingCount()).isEqualTo(4L)
+		);
+	}
+
+	@Test
+	@DisplayName("이미 발급받은 유저가 다시 발급을 시도하면 CouponAlreadyIssuedException이 발생한다.")
+	void shouldThrowExceptionWhenAlreadyIssued() {
+		// given
+		Coupon coupon = Instancio.of(Coupon.class)
+			.ignore(Select.field(Coupon.class, "id"))
+			.set(Select.field(Coupon.class, "couponName"), "중복 테스트 쿠폰")
+			.set(Select.field(Coupon.class, "discountValue"), BigDecimal.valueOf(1000))
+			.set(Select.field(Coupon.class, "discountType"), DiscountType.FIXED)
+			.set(Select.field(Coupon.class, "issuePolicyType"), CouponIssuePolicyType.UNLIMITED)
+			.set(Select.field(Coupon.class, "validFrom"), LocalDate.now().minusDays(1))
+			.set(Select.field(Coupon.class, "validTo"), LocalDate.now().plusDays(5))
+			.create();
+
+		couponRepository.save(coupon);
+
+		Long userId = 2L;
+
+		PublishedCoupon publishedCoupon = PublishedCoupon.create(userId, coupon, LocalDate.now());
+		couponRepository.savePublishedCoupon(publishedCoupon);
+
+		CouponIssueCommand command = new CouponIssueCommand(userId, coupon.getId());
+
+		// when & then
+		assertThatThrownBy(() -> couponService.issueCoupon(command))
+			.isInstanceOf(CouponAlreadyIssuedException.class);
+	}
+
+	@Test
+	@DisplayName("LIMITED 정책의 쿠폰이 재고가 없으면 CouponOutOfStockException 예외가 발생하고 쿠폰은 발급되지 않는다.")
+	void shouldThrowExceptionWhenLimitedCouponIsOutOfStock() {
+		// given
+		Coupon coupon = Instancio.of(Coupon.class)
+			.ignore(Select.field(Coupon.class, "id"))
+			.set(Select.field(Coupon.class, "couponName"), "품절 쿠폰")
+			.set(Select.field(Coupon.class, "discountValue"), BigDecimal.valueOf(1000))
+			.set(Select.field(Coupon.class, "discountType"), DiscountType.FIXED)
+			.set(Select.field(Coupon.class, "issuePolicyType"), CouponIssuePolicyType.LIMITED)
+			.set(Select.field(Coupon.class, "remainingCount"), 0L) // 핵심: 잔여 수량 0
+			.set(Select.field(Coupon.class, "validFrom"), LocalDate.now().minusDays(1))
+			.set(Select.field(Coupon.class, "validTo"), LocalDate.now().plusDays(5))
+			.create();
+
+		Coupon savedCoupon = couponRepository.save(coupon);
+
+		Long userId = 10L;
+		CouponIssueCommand command = new CouponIssueCommand(userId, savedCoupon.getId());
+
+		// when & then
+		assertThatThrownBy(() -> couponService.issueCoupon(command))
+			.isInstanceOf(CouponOutOfStockException.class);
+
+		// then
+		assertThatThrownBy(() -> couponRepository.findPublishedCouponBy(userId, savedCoupon.getId()))
+			.isInstanceOf(
+				JpaObjectRetrievalFailureException.class) // EntityNotFoundException이 다시 JpaObjectRetrievalFailureException로 말아서 던져짐
+			.hasMessageContaining("발행된 쿠폰을 찾을 수 없습니다");
+	}
+
+	@Test
+	@DisplayName("이미 사용된 쿠폰을 복원하면 isUsed 값이 false로 바뀐다.")
+	void shouldRestoreUsedPublishedCoupon() {
+		// given
+		Coupon coupon = Instancio.of(Coupon.class)
+			.ignore(Select.field(Coupon.class, "id"))
+			.set(Select.field(Coupon.class, "discountValue"), BigDecimal.valueOf(2000))
+			.set(Select.field(Coupon.class, "discountType"), DiscountType.FIXED)
+			.set(Select.field(Coupon.class, "issuePolicyType"), CouponIssuePolicyType.UNLIMITED)
+			.set(Select.field(Coupon.class, "validFrom"), LocalDate.now().minusDays(1))
+			.set(Select.field(Coupon.class, "validTo"), LocalDate.now().plusDays(3))
+			.create();
+		coupon = couponRepository.save(coupon);
+
+		PublishedCoupon publishedCoupon = PublishedCoupon.create(123L, coupon, LocalDate.now());
+		publishedCoupon.discount(BigDecimal.valueOf(10000), LocalDate.now()); // 쿠폰 사용 처리
+		publishedCoupon = couponRepository.savePublishedCoupon(publishedCoupon);
+
+		// when
+		couponService.restorePublishedCoupon(publishedCoupon.getId());
+
+		// then
+		PublishedCoupon updated = couponRepository.findPublishedCouponById(publishedCoupon.getId());
+
+		assertThat(updated.isUsed()).isFalse();
+	}
+}

--- a/src/test/java/kr/hhplus/be/server/integration/CouponServiceIntegrationTest.java
+++ b/src/test/java/kr/hhplus/be/server/integration/CouponServiceIntegrationTest.java
@@ -62,8 +62,8 @@ public class CouponServiceIntegrationTest extends IntgerationTestSupport {
 		assertAll(
 			() -> assertThat(result.getId()).isEqualTo(savedId),
 			() -> assertThat(result.getUserId()).isEqualTo(100L),
-			() -> assertThat(result.getCouponSnapshot().discountValue()).isEqualByComparingTo(BigDecimal.valueOf(1000)),
-			() -> assertThat(result.getCouponSnapshot().discountType()).isEqualTo(DiscountType.FIXED)
+			() -> assertThat(result.getCouponSnapshot().getDiscountValue()).isEqualByComparingTo(BigDecimal.valueOf(1000)),
+			() -> assertThat(result.getCouponSnapshot().getDiscountType()).isEqualTo(DiscountType.FIXED)
 		);
 	}
 

--- a/src/test/java/kr/hhplus/be/server/integration/OrderFacadeIntegrationTest.java
+++ b/src/test/java/kr/hhplus/be/server/integration/OrderFacadeIntegrationTest.java
@@ -1,0 +1,163 @@
+package kr.hhplus.be.server.integration;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.instancio.Select.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.List;
+
+import org.instancio.Instancio;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import kr.hhplus.be.server.application.order.dto.OrderCreateCommand;
+import kr.hhplus.be.server.application.order.dto.OrderCreateResult;
+import kr.hhplus.be.server.application.order.dto.OrderLine;
+import kr.hhplus.be.server.application.order.facade.OrderFacade;
+import kr.hhplus.be.server.domain.coupon.Coupon;
+import kr.hhplus.be.server.domain.coupon.CouponRepository;
+import kr.hhplus.be.server.domain.coupon.PublishedCoupon;
+import kr.hhplus.be.server.domain.coupon.discountpolicy.DiscountType;
+import kr.hhplus.be.server.domain.order.Order;
+import kr.hhplus.be.server.domain.order.OrderRepository;
+import kr.hhplus.be.server.domain.product.Product;
+import kr.hhplus.be.server.domain.product.ProductRepository;
+import kr.hhplus.be.server.domain.product.exception.ProductOutOfStockException;
+import kr.hhplus.be.server.domain.user.User;
+import kr.hhplus.be.server.domain.user.UserRepository;
+import kr.hhplus.be.server.support.IntgerationTestSupport;
+
+public class OrderFacadeIntegrationTest extends IntgerationTestSupport {
+
+	@Autowired
+	private OrderFacade orderFacade;
+
+	@Autowired
+	private OrderRepository orderRepository;
+
+	@Autowired
+	private CouponRepository couponRepository;
+
+	@Autowired
+	private ProductRepository productRepository;
+
+	@Autowired
+	private UserRepository userRepository;
+
+	@Test
+	@DisplayName("유효한 유저, 상품, 쿠폰으로 주문 생성 시 정상적으로 주문이 생성되고, 재고가 차감되며 할인도 적용된다.")
+	void shouldCreateOrderWithCouponAndApplyDiscount() {
+		// given
+
+		// 유효한 사용자
+		User user = userRepository.save(Instancio.of(User.class)
+			.ignore(field("id"))
+			.create());
+
+		// 주문할 상품
+		Product product = productRepository.save(Instancio.of(Product.class)
+			.ignore(field("id"))
+			.set(field("price"), BigDecimal.valueOf(10000))
+			.set(field("stock"), 100L)
+			.create());
+
+		// 적용할 쿠폰 원장
+		Coupon coupon = couponRepository.save(Coupon.createLimited(
+			"할인쿠폰", BigDecimal.valueOf(3000), DiscountType.FIXED, 10L,
+			LocalDate.now().minusDays(1), LocalDate.now().plusDays(1)
+		));
+
+		// 사용자가 가지고 있는 쿠폰 정의
+		PublishedCoupon publishedCoupon = PublishedCoupon.create(user.getId(), coupon, LocalDate.now());
+		couponRepository.savePublishedCoupon(publishedCoupon);
+
+		OrderCreateCommand command = new OrderCreateCommand(
+			user.getId(),
+			publishedCoupon.getId(),
+			List.of(new OrderLine(product.getId(), 2L)) // 2 x 10,000 = 20,000
+		);
+
+		// when
+		OrderCreateResult result = orderFacade.createOrder(command);
+
+		// then
+		Order order = orderRepository.findOrderById(result.orderId());
+		assertAll(
+			() -> assertThat(order.getUserId()).isEqualTo(user.getId()), // 주문의 사용자 ID == 사용자 ID
+			() -> assertThat(order.getOrderProducts()).hasSize(1),
+			() -> assertThat(order.getTotalPrice()).isEqualByComparingTo("20000"),
+			() -> assertThat(order.getDiscountedPrice()).isEqualByComparingTo("17000"),
+			() -> assertThat(order.getPublishedCouponId()).isEqualTo(publishedCoupon.getId()), // 발급된 쿠폰 적용 확인
+			() -> assertThat(productRepository.findById(product.getId()).getStock()).isEqualTo(98L), // 재고 차감 확인
+			() -> assertThat(couponRepository.findPublishedCouponById(publishedCoupon.getId()).isUsed()).isTrue()
+		);
+	}
+
+	@Test
+	@DisplayName("쿠폰 없이 주문 생성 시 할인 없이 총액만 계산되며 주문이 정상 생성된다.")
+	void shouldCreateOrderWithoutCoupon() {
+		// given
+		User user = userRepository.save(Instancio.of(User.class)
+			.ignore(field("id"))
+			.create());
+
+		Product product = productRepository.save(Instancio.of(Product.class)
+			.ignore(field("id"))
+			.set(field("price"), BigDecimal.valueOf(15000))
+			.set(field("stock"), 50L)
+			.create());
+
+		OrderCreateCommand command = new OrderCreateCommand(
+			user.getId(),
+			null, // 쿠폰 없음
+			List.of(new OrderLine(product.getId(), 3L)) // 3 x 15000 = 45000
+		);
+
+		// when
+		OrderCreateResult result = orderFacade.createOrder(command);
+
+		// then
+		Order order = orderRepository.findOrderById(result.orderId());
+
+		assertAll(
+			() -> assertThat(order.getUserId()).isEqualTo(user.getId()),
+			() -> assertThat(order.getOrderProducts()).hasSize(1),
+			() -> assertThat(order.getTotalPrice()).isEqualByComparingTo(BigDecimal.valueOf(45000)),
+			() -> assertThat(order.getDiscountedPrice()).isEqualByComparingTo(BigDecimal.ZERO),
+			() -> assertThat(order.getPublishedCouponId()).isNull(),
+			() -> assertThat(productRepository.findById(product.getId()).getStock()).isEqualTo(47L)
+		);
+	}
+
+	@Test
+	@DisplayName("상품 재고가 부족하면 주문 생성에 실패한다")
+	void shouldFailWhenStockIsInsufficient() {
+		// given
+		User user = userRepository.save(
+			Instancio.of(User.class)
+				.ignore(field(User.class, "id"))
+				.create()
+		);
+
+		Product product = Instancio.of(Product.class)
+			.ignore(field(Product.class, "id"))
+			.set(field(Product.class, "stock"), 1L) // 재고는 1개
+			.create();
+		product = productRepository.save(product);
+
+		OrderLine orderLine = new OrderLine(product.getId(), 5L); // 5개 요청
+
+		OrderCreateCommand command = new OrderCreateCommand(
+			user.getId(),
+			null,
+			List.of(orderLine)
+		);
+
+		// when & then
+		assertThatThrownBy(() -> orderFacade.createOrder(command))
+			.isInstanceOf(ProductOutOfStockException.class);
+	}
+}

--- a/src/test/java/kr/hhplus/be/server/integration/OrderServiceIntegrationTest.java
+++ b/src/test/java/kr/hhplus/be/server/integration/OrderServiceIntegrationTest.java
@@ -1,0 +1,248 @@
+package kr.hhplus.be.server.integration;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.instancio.Select.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.stream.IntStream;
+
+import org.instancio.Instancio;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import kr.hhplus.be.server.domain.base.BaseTimeEntity;
+import kr.hhplus.be.server.domain.order.Order;
+import kr.hhplus.be.server.domain.order.OrderProduct;
+import kr.hhplus.be.server.domain.order.OrderRepository;
+import kr.hhplus.be.server.domain.order.OrderService;
+import kr.hhplus.be.server.domain.order.OrderStatus;
+import kr.hhplus.be.server.domain.product.Product;
+import kr.hhplus.be.server.domain.product.ProductRepository;
+import kr.hhplus.be.server.domain.user.User;
+import kr.hhplus.be.server.support.IntgerationTestSupport;
+
+public class OrderServiceIntegrationTest extends IntgerationTestSupport {
+
+	@Autowired
+	private OrderService orderService;
+
+	@Autowired
+	private OrderRepository orderRepository;
+
+	@Autowired
+	private ProductRepository productRepository;
+
+	@Test
+	@DisplayName("주문을 주문 상품과 함께 저장한다.")
+	void shouldSaveOrderWithOrderProducts() {
+		// given
+		User user = Instancio.of(User.class)
+			.ignore(field(User.class, "id"))
+			.create();
+
+		Product product1 = Instancio.of(Product.class)
+			.ignore(field(Product.class, "id"))
+			.set(field(Product.class, "price"), BigDecimal.valueOf(5000))
+			.set(field(Product.class, "stock"), 10L)
+			.create();
+
+		Product product2 = Instancio.of(Product.class)
+			.ignore(field(Product.class, "id"))
+			.set(field(Product.class, "price"), BigDecimal.valueOf(10000))
+			.set(field(Product.class, "stock"), 10L)
+			.create();
+
+		Order order = Order.create(user);
+		ReflectionTestUtils.setField(order, "createdAt", LocalDateTime.now());
+		ReflectionTestUtils.setField(order, "updatedAt", LocalDateTime.now());
+
+		order.addOrderProduct(product1, 1L);
+		order.addOrderProduct(product2, 2L);
+
+		// when
+		Order savedOrder = orderService.order(order);
+
+		// then
+		Order findOrder = orderRepository.findOrderById(savedOrder.getId());
+		assertAll(
+			() -> assertThat(findOrder.getOrderProducts()).hasSize(2),
+			() -> assertThat(findOrder.getTotalPrice()).isEqualByComparingTo("25000")
+		);
+	}
+
+	@Test
+	@DisplayName("주문 상태가 PENDING일 때 completeOrder를 호출하면 상태가 PAID로 변경된다.")
+	void shouldChangeOrderStatusToPaidWhenCompleted() {
+		// given
+		User user = Instancio.of(User.class)
+			.ignore(field(User.class, "id"))
+			.create();
+
+		Product product = Instancio.of(Product.class)
+			.ignore(field(Product.class, "id"))
+			.set(field(Product.class, "price"), BigDecimal.valueOf(10000))
+			.set(field(Product.class, "stock"), 10L)
+			.create();
+
+		Order order = Order.create(user);
+		order.addOrderProduct(product, 1L);
+		ReflectionTestUtils.setField(order, "createdAt", LocalDateTime.now());
+		ReflectionTestUtils.setField(order, "updatedAt", LocalDateTime.now());
+
+		order = orderRepository.save(order);
+
+		// when
+		orderService.completeOrder(order);
+
+		// then
+		Order updatedOrder = orderRepository.findOrderById(order.getId());
+
+		assertThat(updatedOrder.getOrderStatus()).isEqualTo(OrderStatus.PAID);
+	}
+
+	@Test
+	@DisplayName("주문 상태가 PENDING일 때 expireOrder를 호출하면 상태가 EXPIRED로 변경된다.")
+	void shouldChangeOrderStatusToExpired() {
+		// given
+		User user = Instancio.of(User.class)
+			.ignore(field(User.class, "id"))
+			.create();
+
+		Product product = Instancio.of(Product.class)
+			.ignore(field(Product.class, "id"))
+			.set(field(Product.class, "price"), BigDecimal.valueOf(8000))
+			.set(field(Product.class, "stock"), 10L)
+			.create();
+
+		Order order = Order.create(user);
+		order.addOrderProduct(product, 1L);
+		ReflectionTestUtils.setField(order, "createdAt", LocalDateTime.now());
+		ReflectionTestUtils.setField(order, "updatedAt", LocalDateTime.now());
+
+		order = orderRepository.save(order); // 초기 상태는 PENDING
+
+		// when
+		Order expiredOrder = orderService.expireOrder(order);
+
+		// then
+		Order findOrder = orderRepository.findOrderById(expiredOrder.getId());
+
+		assertThat(findOrder.getOrderStatus()).isEqualTo(OrderStatus.EXPIRED);
+	}
+
+	@Test
+	@DisplayName("createdAt이 데드라인 이전이고 상태가 PENDING인 주문만 조회된다.")
+	void shouldFilterOnlyPendingAndOverdueOrders() {
+		// given
+		LocalDateTime now = LocalDateTime.now();
+		LocalDateTime deadLine = now.plusMinutes(5);
+
+		List<Order> orders = IntStream.range(0, 5)
+			.mapToObj(i -> {
+				Product product = Instancio.of(Product.class)
+					.ignore(field(Product.class, "id"))
+					.create();
+				OrderProduct orderProduct = OrderProduct.create(product, 1L);
+
+				return Instancio.of(Order.class)
+					.ignore(field(Order.class, "id"))
+					.set(field(Order.class, "orderStatus"), OrderStatus.PENDING)
+					.supply(field(Order.class, "orderProducts"), () -> List.of(orderProduct))
+					.create();
+			})
+			.toList();
+
+		orders.forEach(orderRepository::save);
+
+		// when
+		List<Order> result = orderService.getOverDueOrders(deadLine);
+
+		// then
+		assertThat(result)
+			.allSatisfy(order -> {
+				assertThat(order.getOrderStatus()).isEqualTo(OrderStatus.PENDING);
+				assertThat(order.getCreatedAt()).isBefore(deadLine);
+			});
+	}
+
+	@Test
+	@DisplayName("유효한 주문 ID로 주문을 조회하면 주문과 주문상품이 반환된다")
+	void shouldReturnOrderWithOrderProductsWhenIdIsValid() {
+		// given
+		Product product = Instancio.of(Product.class)
+			.ignore(field(Product.class, "id"))
+			.create();
+
+		OrderProduct orderProduct = OrderProduct.create(product, 1L);
+
+		Order order = Instancio.of(Order.class)
+			.ignore(field(Order.class, "id"))
+			.set(field(Order.class, "orderStatus"), OrderStatus.PENDING)
+			.supply(field(Order.class, "orderProducts"), () -> List.of(orderProduct))
+			.create();
+
+		Order savedOrder = orderRepository.save(order);
+
+		// when
+		Order result = orderService.getOrderById(savedOrder.getId());
+
+		// then
+		assertAll(
+			() -> assertThat(result.getId()).isEqualTo(savedOrder.getId()),
+			() -> assertThat(result.getOrderProducts()).hasSize(1),
+			() -> assertThat(result.getOrderStatus()).isEqualTo(OrderStatus.PENDING)
+		);
+	}
+
+	@Test
+	@DisplayName("주문 ID가 null이면 IllegalArgumentException가 발생한다")
+	void shouldThrowExceptionWhenOrderIdIsNull() {
+		// when & then
+		assertThatThrownBy(() -> orderService.getOrderById(null))
+			.isInstanceOf(IllegalArgumentException.class)
+			.hasMessage("주문 ID는 null일 수 없습니다.");
+	}
+
+	@Test
+	@DisplayName("유효한 orderId로 주문 상품을 조회하면 주문한 상품 목록이 반환된다")
+	void shouldReturnOrderProductsWhenOrderIdIsValid() {
+		// given
+		Product product = Instancio.of(Product.class)
+			.ignore(field(Product.class, "id"))
+			.create();
+
+		OrderProduct orderProduct = OrderProduct.create(product, 2L);
+
+		Order order = Instancio.of(Order.class)
+			.ignore(field(Order.class, "id"))
+			.set(field(Order.class, "orderStatus"), OrderStatus.PENDING)
+			.supply(field(Order.class, "orderProducts"), () -> List.of(orderProduct))
+			.create();
+
+		Order savedOrder = orderRepository.save(order);
+
+		// when
+		List<OrderProduct> orderProducts = orderService.getOrderProducts(savedOrder.getId());
+
+		// then
+		assertAll(
+			() -> assertThat(orderProducts).hasSize(1),
+			() -> assertThat(orderProducts.get(0).getProductId()).isEqualTo(product.getId()),
+			() -> assertThat(orderProducts.get(0).getQuantity()).isEqualTo(2L)
+		);
+	}
+
+	@Test
+	@DisplayName("orderId로 주문한 상품들을 가져올 때, orderId가 null이면 IllegalArgumentException 발생한다")
+	void shouldThrowExceptionWhenOrderIdIsNullIfGetOrderProducts() {
+		// when & then
+		assertThatThrownBy(() -> orderService.getOrderProducts(null))
+			.isInstanceOf(IllegalArgumentException.class)
+			.hasMessage("주문 ID는 null일 수 없습니다.");
+	}
+}

--- a/src/test/java/kr/hhplus/be/server/integration/PointOrderPaymentFacadeIntegrationTest.java
+++ b/src/test/java/kr/hhplus/be/server/integration/PointOrderPaymentFacadeIntegrationTest.java
@@ -1,0 +1,92 @@
+package kr.hhplus.be.server.integration;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.instancio.Select.*;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+import org.instancio.Instancio;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import kr.hhplus.be.server.application.point.PointOrderPaymentFacade;
+import kr.hhplus.be.server.application.point.dto.PointOrderPaymentCommand;
+import kr.hhplus.be.server.domain.order.Order;
+import kr.hhplus.be.server.domain.order.OrderRepository;
+import kr.hhplus.be.server.domain.order.OrderStatus;
+import kr.hhplus.be.server.domain.order.client.DataPlatformClient;
+import kr.hhplus.be.server.domain.point.Balance;
+import kr.hhplus.be.server.domain.point.Point;
+import kr.hhplus.be.server.domain.point.PointRepository;
+import kr.hhplus.be.server.domain.product.Product;
+import kr.hhplus.be.server.domain.product.ProductRepository;
+import kr.hhplus.be.server.domain.user.User;
+import kr.hhplus.be.server.domain.user.UserRepository;
+import kr.hhplus.be.server.support.IntgerationTestSupport;
+
+public class PointOrderPaymentFacadeIntegrationTest extends IntgerationTestSupport {
+
+	@Autowired
+	PointOrderPaymentFacade pointOrderPaymentFacade;
+
+	@Autowired
+	private OrderRepository orderRepository;
+
+	@Autowired
+	private PointRepository pointRepository;
+
+	@Autowired
+	private UserRepository userRepository;
+
+	@Autowired
+	private ProductRepository productRepository;
+
+	@MockitoBean
+	private DataPlatformClient dataPlatformClient;
+
+	@Test
+	@DisplayName("유저 포인트로 결제 시 주문 상태가 PAID로 변경되고 포인트가 차감되며 외부 시스템 전송이 발생한다.")
+	void shouldPayOrderWithPointsSuccessfully() {
+		// given
+		User user = userRepository.save(Instancio.of(User.class)
+			.ignore(field("id"))
+			.create());
+
+		pointRepository.save(Point.create(user.getId(), Balance.createBalance(BigDecimal.valueOf(100_000))));
+
+		Product product = productRepository.save(Instancio.of(Product.class)
+			.ignore(field("id"))
+			.set(field("price"), BigDecimal.valueOf(30000))
+			.set(field("stock"), 50L)
+			.create());
+
+		Order order = Order.create(user);
+		order.addOrderProduct(product, 2L); // 총액: 60,000
+		ReflectionTestUtils.setField(order, "createdAt", LocalDateTime.now());
+		ReflectionTestUtils.setField(order, "updatedAt", LocalDateTime.now());
+
+		orderRepository.save(order);
+
+		PointOrderPaymentCommand command = new PointOrderPaymentCommand(user.getId(), order.getId());
+
+		// when
+		pointOrderPaymentFacade.pointPayment(command);
+
+		// then
+		Order updatedOrder = orderRepository.findOrderById(order.getId());
+		Point userPoint = pointRepository.findByUserId(user.getId());
+
+		assertAll(
+			() -> assertThat(updatedOrder.getOrderStatus()).isEqualTo(OrderStatus.PAID),
+			() -> assertThat(userPoint.getAmount()).isEqualByComparingTo(BigDecimal.valueOf(40_000)),
+			// 100_000 - 60_000
+			() -> verify(dataPlatformClient).send(any(Order.class))
+		);
+	}
+}

--- a/src/test/java/kr/hhplus/be/server/integration/PointServiceIntgerationTest.java
+++ b/src/test/java/kr/hhplus/be/server/integration/PointServiceIntgerationTest.java
@@ -1,0 +1,189 @@
+package kr.hhplus.be.server.integration;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.instancio.Select.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.math.BigDecimal;
+
+import org.instancio.Instancio;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import kr.hhplus.be.server.domain.point.Balance;
+import kr.hhplus.be.server.domain.point.Point;
+import kr.hhplus.be.server.domain.point.PointHistory;
+import kr.hhplus.be.server.domain.point.PointRepository;
+import kr.hhplus.be.server.domain.point.PointService;
+import kr.hhplus.be.server.domain.point.TransactionType;
+import kr.hhplus.be.server.domain.point.dto.PointChargeCommand;
+import kr.hhplus.be.server.domain.point.dto.PointUseCommand;
+import kr.hhplus.be.server.domain.point.exception.PointNotEnoughException;
+import kr.hhplus.be.server.domain.user.User;
+import kr.hhplus.be.server.domain.user.UserRepository;
+import kr.hhplus.be.server.support.IntgerationTestSupport;
+
+public class PointServiceIntgerationTest extends IntgerationTestSupport {
+
+	@Autowired
+	private PointService pointService;
+
+	@Autowired
+	private PointRepository pointRepository;
+
+	@Autowired
+	private UserRepository userRepository;
+
+	@Test
+	@DisplayName("사용자의 포인트가 없는 경우 0으로 초기화한다.")
+	void getPointOfUser() {
+		// given
+		Long userId = 1L;
+
+		// when
+		Point point = pointService.getPointOfUser(userId);
+
+		// then
+		assertAll(
+			() -> assertThat(point.getUserId()).isEqualTo(userId),
+			() -> assertThat(point.getAmount()).isEqualByComparingTo(BigDecimal.ZERO)
+		);
+	}
+
+	@Test
+	@DisplayName("이미 포인트가 존재하는 사용자의 포인트를 조회한다.")
+	void getPointOfExistUser() {
+		// given
+		Long userId = 1L;
+		Point userPoint = Point.create(userId, Balance.createBalance(BigDecimal.TEN));
+		pointRepository.save(userPoint);
+
+		// when
+		Point result = pointRepository.findByUserId(userId);
+
+		// then
+		assertAll(
+			() -> assertThat(result.getUserId()).isEqualTo(userId),
+			() -> assertThat(result.getAmount()).isEqualByComparingTo(BigDecimal.TEN)
+		);
+	}
+
+	@Test
+	@DisplayName("포인트 조회 시 사용자 ID가 null인 경우 IllegalArgumentException 예외를 발생시킨다.")
+	void getPointOfUserWithNullUserId() {
+		// given
+		Long userId = null;
+
+		// when
+		assertThatThrownBy(() -> pointService.getPointOfUser(userId))
+			.isInstanceOf(IllegalArgumentException.class)
+			.hasMessage("userId는 null일 수 없습니다.");
+	}
+
+	@Test
+	@DisplayName("포인트를 충전하면 충전한 금액만큼 잔액이 늘고 포인트 충전이력이 저장된다.")
+	void chargeUserPoint() {
+		// given
+		Long userId = 1L;
+		Point originalPoint = Point.createZeroUserPoint(userId); // 초기 포인트가 0인 객체
+		BigDecimal chargeAmount = BigDecimal.valueOf(1000);
+		PointChargeCommand command = new PointChargeCommand(userId, chargeAmount);
+
+		pointRepository.save(originalPoint);
+
+		// when
+		Point result = pointService.chargeUserPoint(command);
+
+		// then
+		PointHistory pointHistory = pointRepository.getPointHistoryByPointId(result.getId()).get(0);
+		assertAll(
+			() -> assertThat(result.getUserId()).isEqualTo(userId),
+			() -> assertThat(result.getAmount()).isEqualByComparingTo(chargeAmount),
+			() -> assertThat(pointHistory.getPointId()).isEqualTo(result.getId()),
+			() -> assertThat(pointHistory.getAmount()).isEqualByComparingTo(chargeAmount),
+			() -> assertThat(pointHistory.getType()).isEqualTo(TransactionType.CHARGE),
+			() -> assertThat(pointHistory.getBalance()).isEqualByComparingTo(result.getAmount())
+		);
+	}
+
+	@Test
+	@DisplayName("포인트 충전시 충전하고자하는 userId가 null이라면 IllegalArgumentException이 발생한다.")
+	void chargeUserPointWithNullUserId() {
+		// given
+		Long userId = null;
+		BigDecimal chargeAmount = BigDecimal.valueOf(1000);
+		PointChargeCommand command = new PointChargeCommand(userId, chargeAmount);
+
+		// when
+		assertThatThrownBy(() -> pointService.chargeUserPoint(command))
+			.isInstanceOf(IllegalArgumentException.class)
+			.hasMessage("userId는 null일 수 없습니다.");
+	}
+
+	@Test
+	@DisplayName("포인트를 사용하면 사용만큼 잔액이 줄어들고 포인트 사용 이력이 저장된다.")
+	void userUserPoint() {
+		// given
+		Long userId = 1L;
+		Point originalPoint = Point.create(userId, Balance.createBalance(BigDecimal.valueOf(1000)));
+		BigDecimal useAmount = BigDecimal.valueOf(500);
+
+		PointUseCommand command = new PointUseCommand(userId, useAmount);
+
+		pointRepository.save(originalPoint);
+
+		// when
+		Point result = pointService.useUserPoint(command);
+
+		// then
+		PointHistory pointHistory = pointRepository.getPointHistoryByPointId(result.getId()).get(0);
+		assertAll(
+			() -> assertThat(result.getUserId()).isEqualTo(userId),
+			() -> assertThat(result.getAmount()).isEqualByComparingTo(BigDecimal.valueOf(500)),
+			() -> assertThat(pointHistory.getPointId()).isEqualTo(result.getId()),
+			() -> assertThat(pointHistory.getAmount()).isEqualByComparingTo(useAmount),
+			() -> assertThat(pointHistory.getType()).isEqualTo(TransactionType.USE),
+			() -> assertThat(pointHistory.getBalance()).isEqualByComparingTo(result.getAmount())
+		);
+	}
+
+	@Test
+	@DisplayName("포인트 충전시 충전하고자하는 userId가 null이라면 IllegalArgumentException이 발생한다.")
+	void useUserPointWithNullUserId() {
+		// given
+		Long userId = null;
+		BigDecimal useAmount = BigDecimal.valueOf(1000);
+		PointUseCommand command = new PointUseCommand(userId, useAmount);
+
+		// when
+		assertThatThrownBy(() -> pointService.useUserPoint(command))
+			.isInstanceOf(IllegalArgumentException.class)
+			.hasMessage("userId는 null일 수 없습니다.");
+	}
+
+	@DisplayName("포인트 잔액이 부족하면 포인트 사용에 실패하고 PointNotEnoughException예외가 발생한다.")
+	@Test
+	void shouldFailWhenPointBalanceIsInsufficient() {
+		// given
+		User user = userRepository.save(
+			Instancio.of(User.class)
+				.ignore(field(User.class, "id"))
+				.create()
+		);
+
+		Point point = Point.builder()
+			.userId(user.getId())
+			.balance(Balance.createBalance(BigDecimal.valueOf(500))) // 현재 잔액: 500원
+			.build();
+		pointRepository.save(point);
+
+		PointUseCommand command = new PointUseCommand(user.getId(), BigDecimal.valueOf(1000)); // 요청: 1000원
+
+		// when & then
+		Point findPoint = pointRepository.findByUserId(user.getId());
+		assertThat(findPoint.getAmount()).isEqualByComparingTo(BigDecimal.valueOf(500));
+		assertThatThrownBy(() -> pointService.useUserPoint(command))
+			.isInstanceOf(PointNotEnoughException.class);
+	}
+}

--- a/src/test/java/kr/hhplus/be/server/integration/ProductServiceIntgerationTest.java
+++ b/src/test/java/kr/hhplus/be/server/integration/ProductServiceIntgerationTest.java
@@ -1,0 +1,169 @@
+package kr.hhplus.be.server.integration;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.stream.IntStream;
+
+import org.instancio.Instancio;
+import org.instancio.Select;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import kr.hhplus.be.server.support.IntgerationTestSupport;
+import kr.hhplus.be.server.domain.product.Product;
+import kr.hhplus.be.server.domain.product.ProductRepository;
+import kr.hhplus.be.server.domain.product.ProductService;
+import kr.hhplus.be.server.domain.product.exception.ProductOutOfStockException;
+
+public class ProductServiceIntgerationTest extends IntgerationTestSupport {
+
+	@Autowired
+	private ProductService productService;
+
+	@Autowired
+	private ProductRepository productRepository;
+
+	@Test
+	@DisplayName("상품 단건을 조회할 수 있다.")
+	void shouldReturnProductWhenIdIsValid() {
+		// given
+		Product product = Instancio.of(Product.class)
+			.ignore(Select.field(Product.class, "id")) // DB가 자동 생성할 ID는 무시
+			.set(Select.field(Product.class, "productName"), "상품A")
+			.set(Select.field(Product.class, "price"), BigDecimal.valueOf(10000))
+			.set(Select.field(Product.class, "stock"), 10L)
+			.create();
+
+		productRepository.save(product); // 실제 DB 저장
+		Long savedId = product.getId();
+
+		// when
+		Product result = productService.getProductById(savedId);
+
+		// then
+		assertAll(
+			() -> assertThat(result.getId()).isEqualTo(savedId),
+			() -> assertThat(result.getProductName()).isEqualTo("상품A"),
+			() -> assertThat(result.getPrice()).isEqualByComparingTo("10000"),
+			() -> assertThat(result.getStock()).isEqualTo(10L)
+		);
+	}
+
+	@Test
+	@DisplayName("상품 목록을 조회한다.")
+	void test() {
+		int numberOfProducts = 5;
+		IntStream.rangeClosed(1, numberOfProducts)
+			.forEach(i -> {
+				Product product = Product.create(
+					"상품" + i,
+					"상품 설명" + i,
+					BigDecimal.valueOf(i * 100L),
+					1000L * i
+				);
+				productRepository.save(product);
+			});
+
+		// when
+		List<Product> products = productService.getAllProducts();
+
+		// then
+		assertThat(products)
+			.hasSize(numberOfProducts)
+			.extracting(Product::getProductName)
+			.containsExactlyInAnyOrder(
+				IntStream.rangeClosed(1, numberOfProducts)
+					.mapToObj(i -> "상품" + i)
+					.toArray(String[]::new)
+			);
+	}
+
+	// TODO 상품 재고 차감 테스트
+	@Test
+	@DisplayName("상품 재고는 주문 수량만큼 차감된다.")
+	void shouldDecreaseStockWhenProductIsOrdered() {
+		// given
+		Product product = Instancio.of(Product.class)
+			.ignore(Select.field(Product.class, "id"))
+			.set(Select.field(Product.class, "stock"), 10L)
+			.create();
+
+		productRepository.save(product);
+		Long savedId = product.getId();
+
+		// when
+		productService.decreaseStock(product, 3L);
+
+		// then
+		Product updated = productRepository.findById(savedId);
+
+		assertThat(updated.getStock()).isEqualTo(7L);
+	}
+
+	@Test
+	@DisplayName("상품 재고 차감이 실패하면 재고는 그대로다.")
+	void shouldNotChangeStockWhenDecreaseFails() {
+		// given
+		Product product = Instancio.of(Product.class)
+			.ignore(Select.field(Product.class, "id"))
+			.set(Select.field(Product.class, "stock"), 5L)
+			.create();
+
+		productRepository.save(product);
+		Long savedId = product.getId();
+
+		// when & then
+		assertThatThrownBy(() -> productService.decreaseStock(product, 10L)) // 재고 초과 차감
+			.isInstanceOf(ProductOutOfStockException.class);
+
+		Product updated = productRepository.findById(savedId);
+		assertThat(updated.getStock()).isEqualTo(5L); // 재고는 그대로여야 한다
+	}
+
+	// TODO 상품 재고 원복(증가) 테스트
+	@Test
+	@DisplayName("상품 재고는 입력 수량만큼 정상적으로 증가한다.")
+	void shouldIncreaseStockWhenValidQuantityIsGiven() {
+		// given
+		Product product = Instancio.of(Product.class)
+			.ignore(Select.field(Product.class, "id"))
+			.set(Select.field(Product.class, "stock"), 5L)
+			.create();
+
+		productRepository.save(product);
+		Long savedId = product.getId();
+
+		// when
+		productService.restoreStock(savedId, 3L); // 5 + 3 = 8
+
+		// then
+		Product updated = productRepository.findById(savedId);
+		assertThat(updated.getStock()).isEqualTo(8L);
+	}
+
+	@Test
+	@DisplayName("재고 증가에 실패하면 상품 재고는 그대로다.")
+	void shouldNotChangeStockWhenIncreaseFails() {
+		// given
+		Product product = Instancio.of(Product.class)
+			.ignore(Select.field(Product.class, "id"))
+			.set(Select.field(Product.class, "stock"), 5L)
+			.create();
+
+		productRepository.save(product);
+		Long savedId = product.getId();
+
+		// when & then
+		assertThatThrownBy(() -> productService.restoreStock(savedId, 0L))
+			.isInstanceOf(IllegalArgumentException.class)
+			.hasMessageContaining("수량이 null이거나 0 이하입니다.");
+
+		// then
+		Product updated = productRepository.findById(savedId);
+		assertThat(updated.getStock()).isEqualTo(5L); // 재고 변화 없음
+		}
+}

--- a/src/test/java/kr/hhplus/be/server/integration/UserServiceIntgerationTest.java
+++ b/src/test/java/kr/hhplus/be/server/integration/UserServiceIntgerationTest.java
@@ -1,0 +1,42 @@
+package kr.hhplus.be.server.integration;
+
+import static org.assertj.core.api.Assertions.*;
+
+import org.instancio.Instancio;
+import org.instancio.Select;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import kr.hhplus.be.server.support.IntgerationTestSupport;
+import kr.hhplus.be.server.domain.user.User;
+import kr.hhplus.be.server.domain.user.UserRepository;
+import kr.hhplus.be.server.domain.user.UserService;
+
+public class UserServiceIntgerationTest extends IntgerationTestSupport {
+
+	@Autowired
+	private UserService userService;
+
+	@Autowired
+	private UserRepository userRepository;
+
+	@Test
+	@DisplayName("사용자 ID로 조회하면 해당 사용자가 반환된다.")
+	void shouldReturnUserWhenIdIsValid() {
+		// given
+		User user = Instancio.of(User.class)
+			.ignore(Select.field(User.class, "id")) // ID는 DB가 생성
+			.create();
+
+		userRepository.save(user);
+		Long savedId = user.getId();
+
+		// when
+		User result = userService.getUserById(savedId);
+
+		// then
+		assertThat(result.getId()).isEqualTo(savedId);
+	}
+
+}

--- a/src/test/java/kr/hhplus/be/server/support/DbCleaner.java
+++ b/src/test/java/kr/hhplus/be/server/support/DbCleaner.java
@@ -1,0 +1,49 @@
+package kr.hhplus.be.server.support;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.springframework.beans.factory.InitializingBean;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Component;
+
+import jakarta.annotation.PostConstruct;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import jakarta.persistence.Table;
+import jakarta.transaction.Transactional;
+
+@Component
+@Profile("test")
+public class DbCleaner implements InitializingBean {
+	@PersistenceContext
+	private EntityManager entityManager;
+
+	private final List<String> tables = new ArrayList<>();
+
+	@PostConstruct
+	public void afterPropertiesSet() {
+		tables.addAll(
+			entityManager.getMetamodel().getEntities().stream()
+				.filter(entity -> entity.getJavaType().isAnnotationPresent(Entity.class))
+				.map(entity -> entity.getJavaType().getAnnotation(Table.class).name())
+				.toList()
+		);
+	}
+
+	@Transactional
+	public void execute() {
+		entityManager.flush();
+		entityManager.createNativeQuery("SET FOREIGN_KEY_CHECKS = 0").executeUpdate();
+		for (String table : tables) {
+			entityManager.createNativeQuery("TRUNCATE TABLE " + table).executeUpdate();
+			try { // PK 가 Auto Increment 아니면 Exception 발생!!!!!!!!!!!!!!!!!!!
+				entityManager.createNativeQuery("ALTER TABLE " + table + " AUTO_INCREMENT = 1").executeUpdate();
+			} catch (Exception ignored) {
+				ignored.printStackTrace();
+			}
+			entityManager.createNativeQuery("SET FOREIGN_KEY_CHECKS = 1").executeUpdate();
+		}
+	}
+}

--- a/src/test/java/kr/hhplus/be/server/support/IntgerationTestSupport.java
+++ b/src/test/java/kr/hhplus/be/server/support/IntgerationTestSupport.java
@@ -1,0 +1,21 @@
+package kr.hhplus.be.server.support;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+@ActiveProfiles("test")
+@SpringBootTest
+@Testcontainers
+public abstract class IntgerationTestSupport {
+
+	@Autowired
+	private DbCleaner dbCleaner;
+
+	@BeforeEach
+	public void clean() {
+		dbCleaner.execute();
+	}
+}

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -1,0 +1,13 @@
+spring:
+  application:
+    name: hhplus-test
+  datasource:
+    url: jdbc:mysql://localhost:3306/hhplus?characterEncoding=UTF-8&serverTimezone=Asia/Seoul
+    username: test
+    password: test
+  jpa:
+    open-in-view: false
+    generate-ddl: false
+    show-sql: true
+    hibernate:
+      ddl-auto: create-drop  # 테스트용 DB를 매번 초기화


### PR DESCRIPTION
### **커밋 링크**
<!-- 
좋은 피드백을 받기 위해 가장 중요한 것은 코드를 작성할 때 커밋을 작업 단위로 잘 쪼개는 것입니다.
모든 작업을 하나의 커밋에 진행하고 PR을 하면 구조 파악에 많은 시간을 소모하기 때문에 절대로
좋은 피드백을 받을 수 없습니다.


필수 양식)
커밋 이름 : 커밋 링크

예시)
동시성 처리 : c83845
동시성 테스트 코드 : d93ji3
-->

도메인 모델 리팩토링은 다른 브랜치에서 진행했습니다!

포인트 : d5f2a0b
쿠폰 : 58001f3
주문 : 3b86662
상품 : 695e98d

인기상품 인프라 코드 작성 및 통합 테스트 및 추가본 : 63e74f6, 2145639
쿠폰 인프라 코드 작성 및 통합 테스트 : 64442fa
사용자 인프라 코드 작성 및 통합 테스트 : 9dd7f09
포인트 인프라 코드 작성 및 통합 테스트 : de17c0e
상품 인프라 코드 작성, 상품 통합 테스트 : e8e74cc, df3862d

---
### **리뷰 포인트(질문)**

-  Instancio를 조금 써봤는데 테스트에서 사용하기 좋은 꿀팁이 있다면 알려주시면 감사드리겠습니다.
-  JPA Auditing으로 생성해주는 created_at, 가령 주문에서는 주문이 데이터베이스에 삽입된 시간을 기준으로 조회를 하는 테스트에서는 이를 활용하기가 어렵다보니(기존의 운영 코드를 또 테스트를 위해 바꿀 순 없어서) orderedAt으로 뺐는데요. 권장하지 않는 방법일까요? 애플리케이션에서 생성(발생) 시간과 DB에서 넣어주는 생성 시간이 약간의 오차는 있을만도 한데 무시 가능한 수준일까요?
- 연관 관계를 사용하지 않고 인프라쪽 코드를 짜보기는 처음인데 오답인지 정답인지 궁금합니다!
- 저번 주차에 주신 피드백으로 좀 더 넓은 시야를 갖게 된 것 같습니다. 아직 익숙치는 않지만 꾸준히 연습 하겠습니다.
