### PR TITLE
STEP18 : 쿠폰 발급 카프카로 처리 로직 작성 및 테스트

### DIFF
--- a/src/main/java/kr/hhplus/be/server/config/kafka/KafkaTopicConfig.java
+++ b/src/main/java/kr/hhplus/be/server/config/kafka/KafkaTopicConfig.java
@@ -19,4 +19,14 @@ public class KafkaTopicConfig {
 			.replicas(1)
 			.build();
 	}
+
+	@Bean
+	public NewTopic couponIssueTopic() {
+		String topicName = "coupon-issue";
+		log.info("쿠폰 발급 토픽 생성 설정: {}", topicName);
+		return TopicBuilder.name(topicName)
+			.partitions(1)  // 선착순 보장을 위해 단일 파티션
+			.replicas(1)
+			.build();
+	}
 }

--- a/src/main/java/kr/hhplus/be/server/domain/coupon/CouponService.java
+++ b/src/main/java/kr/hhplus/be/server/domain/coupon/CouponService.java
@@ -6,6 +6,8 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import kr.hhplus.be.server.domain.coupon.dto.CouponIssueCommand;
+import kr.hhplus.be.server.domain.coupon.event.CouponEventPublisher;
+import kr.hhplus.be.server.domain.coupon.event.type.CouponIssueRequestEvent;
 import kr.hhplus.be.server.domain.coupon.exception.CouponAlreadyIssuedException;
 import kr.hhplus.be.server.support.aop.lock.DistributedLock;
 import kr.hhplus.be.server.support.aop.lock.SpinLock;
@@ -18,6 +20,7 @@ import lombok.extern.slf4j.Slf4j;
 public class CouponService {
 
 	private final CouponRepository couponRepository;
+	private final CouponEventPublisher couponEventPublisher;
 
 	public PublishedCoupon getPublishedCouponById(Long publishedCouponId) {
 		if (publishedCouponId == null) {
@@ -96,6 +99,11 @@ public class CouponService {
 		}
 	}
 
+	public void issueRequest(CouponIssueCommand command) {
+		log.info("쿠폰 발급 요청을 이벤트로 발행: {}", command);
+		couponEventPublisher.publish(new CouponIssueRequestEvent(command.userId(), command.couponId()));
+	}
+
 	@Transactional
 	public void restorePublishedCoupon(Long publishedCouponId) {
 		if (publishedCouponId == null) {
@@ -106,4 +114,5 @@ public class CouponService {
 		publishedCoupon.restore();
 		couponRepository.savePublishedCoupon(publishedCoupon);
 	}
+
 }

--- a/src/main/java/kr/hhplus/be/server/domain/coupon/event/CouponEventPublisher.java
+++ b/src/main/java/kr/hhplus/be/server/domain/coupon/event/CouponEventPublisher.java
@@ -1,0 +1,8 @@
+package kr.hhplus.be.server.domain.coupon.event;
+
+import kr.hhplus.be.server.domain.coupon.event.type.CouponIssueRequestEvent;
+
+public interface CouponEventPublisher {
+
+	void publish(CouponIssueRequestEvent event);
+}

--- a/src/main/java/kr/hhplus/be/server/domain/coupon/event/type/CouponIssueRequestEvent.java
+++ b/src/main/java/kr/hhplus/be/server/domain/coupon/event/type/CouponIssueRequestEvent.java
@@ -1,0 +1,7 @@
+package kr.hhplus.be.server.domain.coupon.event.type;
+
+public record CouponIssueRequestEvent(
+	Long userId,
+	Long couponId
+) {
+}

--- a/src/main/java/kr/hhplus/be/server/infra/coupon/kafka/CouponKafkaProducer.java
+++ b/src/main/java/kr/hhplus/be/server/infra/coupon/kafka/CouponKafkaProducer.java
@@ -1,0 +1,45 @@
+package kr.hhplus.be.server.infra.coupon.kafka;
+
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.stereotype.Component;
+
+import kr.hhplus.be.server.domain.coupon.event.CouponEventPublisher;
+import kr.hhplus.be.server.domain.coupon.event.type.CouponIssueRequestEvent;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class CouponKafkaProducer implements CouponEventPublisher {
+
+	private final KafkaTemplate<String, Object> kafkaTemplate;
+	private static final String TOPIC_COUPON_ISSUE = "coupon-issue";
+
+	@Override
+	public void publish(CouponIssueRequestEvent event) {
+		try {
+			log.info("쿠폰 발급 요청 이벤트 발행 시작: {}", event);
+
+			// 순서 보장을 위해 couponId를 키로 사용
+			// KafkaTemplate의 send 메서드를 사용하여 이벤트를 발행
+			kafkaTemplate.send(
+					TOPIC_COUPON_ISSUE,
+					event.couponId().toString(),
+					event)
+				.whenComplete((result, ex) -> {
+					if (ex == null) {
+						log.info("쿠폰 발급 요청 이벤트 발행 성공: {}, offset={}, partition={}",
+							result,
+							result.getRecordMetadata().offset(),
+							result.getRecordMetadata().partition());
+					} else {
+						log.error("쿠폰 발급 요청 이벤트 발행 실패: {}", event, ex);
+					}
+				});
+		} catch (Exception e) {
+			log.error("쿠폰 발급 요청 이벤트 발행 중 예외 발생: {}", event, e);
+			throw new RuntimeException("쿠폰 발급 요청 이벤트 전송 실패", e);
+		}
+	}
+}

--- a/src/main/java/kr/hhplus/be/server/interfaces/api/coupon/CouponController.java
+++ b/src/main/java/kr/hhplus/be/server/interfaces/api/coupon/CouponController.java
@@ -42,4 +42,10 @@ public class CouponController implements CouponControllerSpec {
 	public void issueCouponV4(@Valid @RequestBody CouponIssueRequest request) {
 		couponService.issueWithRedis(request.toIssueCommand());
 	}
+
+	@PostMapping("/issue/kafka")
+	@ResponseStatus(HttpStatus.NO_CONTENT)
+	public void issueCouponV5(@Valid @RequestBody CouponIssueRequest request){
+		couponService.issueRequest(request.toIssueCommand());
+	}
 }

--- a/src/main/java/kr/hhplus/be/server/interfaces/consumer/CouponKafkaConsumer.java
+++ b/src/main/java/kr/hhplus/be/server/interfaces/consumer/CouponKafkaConsumer.java
@@ -1,0 +1,52 @@
+package kr.hhplus.be.server.interfaces.consumer;
+
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.kafka.support.KafkaHeaders;
+import org.springframework.messaging.handler.annotation.Header;
+import org.springframework.stereotype.Component;
+
+import kr.hhplus.be.server.domain.coupon.CouponService;
+import kr.hhplus.be.server.domain.coupon.dto.CouponIssueCommand;
+import kr.hhplus.be.server.domain.coupon.event.type.CouponIssueRequestEvent;
+import kr.hhplus.be.server.domain.coupon.exception.CouponAlreadyIssuedException;
+import kr.hhplus.be.server.domain.coupon.exception.CouponOutOfStockException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class CouponKafkaConsumer {
+
+	private final CouponService couponService;
+	private static final String TOPIC_COUPON_ISSUE = "coupon-issue";
+
+	@KafkaListener(topics = TOPIC_COUPON_ISSUE, groupId = "coupon-issue-group")
+	public void consume(CouponIssueRequestEvent event,
+		@Header(KafkaHeaders.RECEIVED_TOPIC) String topic,
+		@Header(KafkaHeaders.RECEIVED_PARTITION) int partition,
+		@Header(KafkaHeaders.OFFSET) String offset) {
+
+		try {
+			log.info("쿠폰 발급 요청 이벤트 수신: {}, topic: {}, partition: {}, offset: {}", event, topic, partition, offset);
+
+			couponService.issueCoupon(
+				new CouponIssueCommand(
+					event.userId(),
+					event.couponId()));
+
+			log.info("쿠폰 발급 완료: {}, topic: {}, partition: {}, offset: {}", event, topic, partition, offset);
+		} catch (CouponOutOfStockException e) {
+			// 쿠폰 재고 부족은 정상적인 실패임
+			log.info("쿠폰 재고 부족으로 발급 실패 : offset={}, message={}", offset, e.getMessage());
+
+		} catch (CouponAlreadyIssuedException e) {
+			// 쿠폰 중복 발급은 정상적인 실패임
+			log.info("중복 발급 시도: offset={}, userId={}", offset, event.userId());
+
+		} catch (Exception e) {
+			log.error("쿠폰 발급 처리 중 오류 발생: {}, topic: {}, partition: {}, offset: {}", event, topic, partition, offset, e);
+			// 실패 이벤트들을 모아두는 별도의 저장소에 저장하는 로직
+		}
+	}
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -52,6 +52,9 @@ spring:
       value-deserializer: org.springframework.kafka.support.serializer.JsonDeserializer
       enable-auto-commit: false
       auto-commit-interval: 1000
+      properties:
+        spring.json.trusted.packages: "*"
+
     admin:
       properties:
         bootstrap.servers: localhost:9092

--- a/src/test/java/kr/hhplus/be/server/concurrency/CouponServiceConcurrencyTest.java
+++ b/src/test/java/kr/hhplus/be/server/concurrency/CouponServiceConcurrencyTest.java
@@ -1,28 +1,37 @@
 package kr.hhplus.be.server.concurrency;
 
 import static org.assertj.core.api.Assertions.*;
+import static org.awaitility.Awaitility.*;
 import static org.instancio.Select.*;
 import static org.junit.jupiter.api.Assertions.*;
 
+import java.util.ArrayList;
 import java.util.List;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Collectors;
+import java.util.stream.LongStream;
 
 import org.instancio.Instancio;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.bean.override.mockito.MockitoSpyBean;
 
 import kr.hhplus.be.server.domain.coupon.Coupon;
 import kr.hhplus.be.server.domain.coupon.CouponService;
 import kr.hhplus.be.server.domain.coupon.PublishedCoupon;
 import kr.hhplus.be.server.domain.coupon.dto.CouponIssueCommand;
+import kr.hhplus.be.server.domain.coupon.event.CouponEventPublisher;
 import kr.hhplus.be.server.domain.coupon.issuePolicy.CouponIssuePolicyType;
 import kr.hhplus.be.server.infra.coupon.CouponJpaRepository;
 import kr.hhplus.be.server.infra.coupon.PublishedCouponJpaRepository;
+import kr.hhplus.be.server.interfaces.consumer.CouponKafkaConsumer;
 import kr.hhplus.be.server.support.IntgerationTestSupport;
 
 public class CouponServiceConcurrencyTest extends IntgerationTestSupport {
@@ -35,6 +44,12 @@ public class CouponServiceConcurrencyTest extends IntgerationTestSupport {
 
 	@Autowired
 	private PublishedCouponJpaRepository publishedCouponJpaRepository;
+
+	@MockitoSpyBean
+	private CouponEventPublisher couponEventPublisher;
+
+	@MockitoSpyBean
+	private CouponKafkaConsumer couponKafkaConsumer;
 
 	@Test
 	@DisplayName("동시성 제어 성공 테스트(비관적 락) : 한 명의 사용자가 동시에 쿠폰 발급을 요청 했을 때, 쿠폰 수량은 1개만 줄고 발급된 쿠폰은 1건이 생성")
@@ -171,7 +186,6 @@ public class CouponServiceConcurrencyTest extends IntgerationTestSupport {
 		exec.shutdown();
 		exec.awaitTermination(3, TimeUnit.SECONDS);
 
-
 		long elapsedTime = System.currentTimeMillis() - startTime;
 		System.out.println("전체 요청 처리 시간(ms): " + elapsedTime);
 
@@ -244,5 +258,78 @@ public class CouponServiceConcurrencyTest extends IntgerationTestSupport {
 			() -> assertThat(after.getRemainingCount()).isEqualTo(0L),
 			() -> assertThat(issued.size()).isEqualTo(10)
 		);
+	}
+
+	@Test
+	@DisplayName("카프카 쿠폰 발급 : 쿠폰 10개에 사용자 20명 - 정확히 10개만 발급되어야 한다.")
+	void couponIssueKafkaTest() throws InterruptedException {
+		// given
+		Coupon savedCoupon = couponJpaRepository.save(
+			Instancio.of(Coupon.class)
+				.ignore(field(Coupon.class, "id"))
+				.set(field(Coupon.class, "issuePolicyType"), CouponIssuePolicyType.LIMITED)
+				.set(field(Coupon.class, "remainingCount"), 10L)
+				.create()
+		);
+
+		int userCount = 20;
+		CountDownLatch startLatch = new CountDownLatch(1);
+		CountDownLatch doneLatch = new CountDownLatch(userCount);
+		ExecutorService executorService = Executors.newFixedThreadPool(userCount);
+
+		List<CompletableFuture<Void>> futures = new ArrayList<>();
+		List<Long> userIds = LongStream.rangeClosed(1, userCount).boxed().toList();
+
+		// when
+		for (Long userId : userIds) {
+			CompletableFuture<Void> future = CompletableFuture.runAsync(() -> {
+				try {
+					startLatch.await();
+
+					CouponIssueCommand command = new CouponIssueCommand(userId, savedCoupon.getId());
+					couponService.issueRequest(command);
+
+				} catch (Exception ignored) {
+					// 예외 무시
+				} finally {
+					doneLatch.countDown();
+				}
+			}, executorService);
+
+			futures.add(future);
+		}
+
+		startLatch.countDown();
+
+		// 모든 요청 완료 대기
+		boolean completed = doneLatch.await(10, TimeUnit.SECONDS);
+		assertThat(completed).isTrue();
+
+		// 카프카 처리 완료 대기
+		await().atMost(30, TimeUnit.SECONDS)
+			.untilAsserted(() -> {
+				// 1. 쿠폰 재고가 0이 되었는지 확인
+				Coupon finalCoupon = couponJpaRepository.findById(savedCoupon.getId()).orElseThrow();
+				assertThat(finalCoupon.getRemainingCount()).isEqualTo(0L);
+
+				// 2. 정확히 10개의 쿠폰만 발급되었는지 확인
+				List<PublishedCoupon> publishedCoupons =
+					publishedCouponJpaRepository.findAll();
+				assertThat(publishedCoupons).hasSize(10);
+
+				// 3. 발급받은 사용자 ID가 모두 다른지 확인
+				List<Long> issuedUserIds = publishedCoupons.stream()
+					.map(PublishedCoupon::getUserId)
+					.collect(Collectors.toList());
+				assertThat(issuedUserIds).hasSize(10);
+
+				// 4. 발급받지 못한 사용자가 10명인지 확인
+				Set<Long> allUserIds = LongStream.rangeClosed(1, 20)
+					.boxed()
+					.collect(Collectors.toSet());
+				allUserIds.removeAll(issuedUserIds);
+				assertThat(allUserIds).hasSize(10); // 10명은 발급받지 못함
+			});
+		executorService.shutdown();
 	}
 }


### PR DESCRIPTION
### **커밋 링크**

- 선착순 쿠폰 발급 카프카를 통해 해결하도록 변경 : 3fc3f7d
---
### **리뷰 포인트(질문)**

- 여기서는 주문 정보 전송과는 달리 곧바로 카프카 프로듀서로 메세지를 전송했습니다. 코드에 문제가 없는지 궁금합니다!
- 파티션 한 개에서 메세지는 순차적으로 처리된다는 점을 이용해서 선착순 이벤트를 처리했습니다. 쿠폰 발행 요청을 받는 서버(프로듀서)와 쿠폰 원장에서 실제로 재고를 차감하고 발급된 쿠폰에 대한 정보를 갖고 있는 서버(컨슈머)가 있다고 가정을 했는데 이를 별도로 두는게 합리적일까요? 아니면 실제 MSA 환경에서 본인이 메세지를 발행하고 본인이 Consume하는 경우도 있나요? 단순히 카프카 개요 영상 같은 것을 봤을땐 서로 다른 서버간 통신의 매개 역할을 한다고만 이해했는데, 오해인지 궁금합니다.
- 이외에도 직렬화 문제 때문에 properties.spring.json.trusted.packages: "*" 옵션을 사용했는데 개발 편의상으론 좋지만 보안적으로는 좋지 않다고 들었습니다. 다른 해결 방법이 있을까요?
- 테스트 코드에서의 검증 로직이 적절한지 궁금합니다!

---
### **이번주 KPT 회고**

### Keep

- 레디스와는 달리 튜토리얼도 안해본 기술이었는데 어찌저찌 과제 완수한 것.

### Problem
- 애플리케이션에서 작성하는 Producer, Consumer 코드에 대해서 좀 더 정리할 필요가 있어보인다.

### Try

- 카프카라는 기술에대해 좀 더 익숙해질 필요가 있고, 다양한 가설을 세워보면서 메세지 유실이나 재처리에 대해서 학습해야겠다.
- 코스가 끝나고 아웃박스 패턴도 도입해봐야겠다.
